### PR TITLE
fix!: ship text-tool metadata under _meta

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,27 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+
+- **Breaking for programmatic consumers.** Tools that return a text result
+  (`read`, `list`, `diff`, `patch`, `edit`, `delete`, `move`, `replace_text`,
+  `search_text`, `find_files`) now ship their metadata under `_meta` instead of
+  `structuredContent`. Clients that treat `structuredContent` as the canonical
+  model view — Claude Code among them — discard the text blocks whenever it is
+  present, so the model never saw the file `read` returned or the tree from
+  `list`. The metadata is the same object under a different field.
+- `read` appends a `// truncated:` line carrying the continuation args, and a
+  `// sha256:` line when `includeHash` is set, after a blank line so neither can
+  be read as file bytes. `list` appends a `nextCursor:` line, and a `truncated:`
+  notice on hard-cap overflow.
+- No tool publishes an `outputSchema` any more. Publishing one obliges the
+  result to carry `structuredContent`, which every publisher has stopped doing.
+- `stat`, `create` and `list_roots` no longer return a one-line text summary.
+  Their value is the metadata, so they return JSON text and keep
+  `structuredContent`.
+
 ## [2.0.0] - 2026-08-27
 
 This is a breaking release. Every tool name and every environment variable

--- a/__tests__/helpers.ts
+++ b/__tests__/helpers.ts
@@ -492,13 +492,13 @@ export function firstTextBlock(result: { content: readonly unknown[] }): {
 }
 
 /** Structured per-path failure summary from a read/search tool result. */
-export function failedSummary(result: { structuredContent?: unknown }):
+export function failedSummary(result: { _meta?: unknown }):
   | {
       results?: { error?: { code?: string; message?: string } }[];
       summary?: { failed?: number };
     }
   | undefined {
-  return result.structuredContent as
+  return result._meta as
     | {
         results?: { error?: { code?: string; message?: string } }[];
         summary?: { failed?: number };

--- a/__tests__/http-server.test.ts
+++ b/__tests__/http-server.test.ts
@@ -76,9 +76,9 @@ describe('Real HTTP Server integration', () => {
         name: 'diff',
         arguments: { a: fileA, b: fileB },
       })) as {
-        structuredContent?: { resourceUri?: string };
+        _meta?: { resourceUri?: string };
       };
-      const uri = res.structuredContent?.resourceUri;
+      const uri = res._meta?.resourceUri;
       assert.ok(uri, 'diff must externalize a result uri');
       const read = await client.readResource({ uri });
       assert.ok(read.contents.length > 0, 'the externalized result must be readable');

--- a/__tests__/inspector-stdio.test.ts
+++ b/__tests__/inspector-stdio.test.ts
@@ -274,7 +274,7 @@ describe('Inspector CLI: Stdio Integration & Conformance', { skip: inspectorSkip
   it('INSP-STDIO-009: tools/call out-of-boundary path traversal returns ACCESS_DENIED', async () => {
     const badPath = join(tmpDir, '../../../../etc/shadow');
     const res = await executeInspectorCli<{
-      structuredContent?: {
+      _meta?: {
         results?: { error?: { code?: string; message?: string } }[];
       };
     }>({
@@ -295,7 +295,7 @@ describe('Inspector CLI: Stdio Integration & Conformance', { skip: inspectorSkip
       5,
       `Out-of-root access should surface as a tool error (exit 5). Actual: ${res.exitCode}, stdout: ${res.stdout}`,
     );
-    const firstResult = res.json?.structuredContent?.results?.[0];
+    const firstResult = res.json?._meta?.results?.[0];
     assert.strictEqual(firstResult?.error?.code, 'ACCESS_DENIED');
   });
 

--- a/__tests__/stdio.test.ts
+++ b/__tests__/stdio.test.ts
@@ -125,7 +125,7 @@ describe('Stdio Transport (real subprocess)', () => {
       name: 'list',
       arguments: { path: pageDir, maxEntries: 1 },
     });
-    const cursor = (first.structuredContent as { nextCursor?: string }).nextCursor;
+    const cursor = (first._meta as { nextCursor?: string }).nextCursor;
     assert.ok(cursor);
 
     const second = await harness.client.callTool({
@@ -134,9 +134,7 @@ describe('Stdio Transport (real subprocess)', () => {
     });
     assert.notStrictEqual(second.isError, true);
     assert.deepStrictEqual(
-      (second.structuredContent as { entries?: { name: string }[] }).entries?.map(
-        (entry) => entry.name,
-      ),
+      (second._meta as { entries?: { name: string }[] }).entries?.map((entry) => entry.name),
       ['bravo.txt'],
     );
   });

--- a/__tests__/subscriptions-listen.test.ts
+++ b/__tests__/subscriptions-listen.test.ts
@@ -432,8 +432,8 @@ describe('HTTP resourcesListChanged listen filter', () => {
       const result = (await client.callTool({
         name: 'diff',
         arguments: { a: fileA, b: fileB },
-      })) as { structuredContent?: { resourceUri?: string } };
-      const uri = result.structuredContent?.resourceUri;
+      })) as { _meta?: { resourceUri?: string } };
+      const uri = result._meta?.resourceUri;
       assert.ok(uri, 'diff must externalize a result resource');
 
       await waitFor(() => received);

--- a/__tests__/tools.test.ts
+++ b/__tests__/tools.test.ts
@@ -97,8 +97,7 @@ describe('P0 Functional Tests - Tools (MCP Client)', () => {
     assert.ok(typeof data === 'string');
     assert.strictEqual(Buffer.from(data, 'base64').equals(pngBytes), true);
 
-    const structured = result.structuredContent as
-      { results?: { value?: { kind?: string } }[] } | undefined;
+    const structured = result._meta as { results?: { value?: { kind?: string } }[] } | undefined;
     assert.strictEqual(structured?.results?.[0]?.value?.kind, 'image');
   });
 
@@ -403,7 +402,7 @@ describe('P0 Functional Tests - Tools (MCP Client)', () => {
       arguments: { paths: [file] },
     });
     assert.notStrictEqual(result.isError, true);
-    const structured = result.structuredContent as
+    const structured = result._meta as
       | {
           results?: { path?: string; value?: { deleted?: boolean } }[];
           summary?: { failed?: number };
@@ -461,7 +460,7 @@ describe('P0 Functional Tests - Tools (MCP Client)', () => {
     });
     assert.notStrictEqual(result.isError, true);
 
-    const structured = result.structuredContent as {
+    const structured = result._meta as {
       results?: { value?: { resourceUri?: string } }[];
     };
     const resourceUri = structured.results?.[0]?.value?.resourceUri;
@@ -658,6 +657,59 @@ describe('P0 Functional Tests - Tools (MCP Client)', () => {
     }
   });
 
+  it('TC-FUNC-073: text tools ship metadata under _meta, data tools under structuredContent', async () => {
+    const file = join(tmpDir, 'meta_split.txt');
+    await writeFile(file, 'one\ntwo\n');
+
+    // read authors its own text (the file), so its metadata moves to _meta —
+    // a client that keys on structuredContent would otherwise hide the bytes.
+    const readRes = await harness.client.callTool({ name: 'read', arguments: { path: file } });
+    assert.notStrictEqual(readRes.isError, true);
+    assert.strictEqual(readRes.structuredContent, undefined);
+    const readMeta = readRes._meta as { summary?: { succeeded?: number } };
+    assert.strictEqual(readMeta.summary?.succeeded, 1);
+
+    // stat authors no text, so the JSON *is* its model-facing view and stays
+    // where a programmatic client already looks for it.
+    const statRes = await harness.client.callTool({ name: 'stat', arguments: { path: file } });
+    assert.notStrictEqual(statRes.isError, true);
+    assert.strictEqual(statRes._meta, undefined);
+    const statStructured = statRes.structuredContent as { summary?: { succeeded?: number } };
+    assert.strictEqual(statStructured.summary?.succeeded, 1);
+  });
+
+  it('TC-FUNC-074: read trailer carries continuation and hash', async () => {
+    const file = join(tmpDir, 'trailer.txt');
+    const body = Array.from({ length: 30 }, (_v, i) => `line${String(i + 1)}`).join('\n');
+    await writeFile(file, `${body}\n`);
+
+    const head = await harness.client.callTool({
+      name: 'read',
+      arguments: { path: file, head: 10, includeHash: true },
+    });
+    const headText = firstTextBlock(head).text ?? '';
+    assert.match(headText, /^\/\/ truncated: .*"startLine":11,"endLine":20\}$/m);
+    assert.match(headText, /^\/\/ sha256: [0-9a-f]{64}$/m);
+    // The file's own lines survive ahead of the trailer, unaltered.
+    assert.ok(headText.startsWith('line1\nline2\n'), headText.slice(0, 40));
+    assert.ok(headText.indexOf('line10') < headText.indexOf('// truncated'));
+
+    // A whole-file read is not truncated and was not asked for a hash.
+    const full = await harness.client.callTool({ name: 'read', arguments: { path: file } });
+    const fullText = firstTextBlock(full).text ?? '';
+    assert.ok(!fullText.includes('// truncated'), 'a full read is not truncated');
+    assert.ok(!fullText.includes('// sha256'), 'no hash unless includeHash');
+
+    // tail has no args that read backwards, so it reports what it showed.
+    const tail = await harness.client.callTool({
+      name: 'read',
+      arguments: { path: file, tail: 10 },
+    });
+    const tailText = firstTextBlock(tail).text ?? '';
+    assert.match(tailText, /^\/\/ truncated: showing last 10 lines$/m);
+    assert.ok(!tailText.includes('Continue:'), 'tail offers no continuation args');
+  });
+
   it('TC-FUNC-060: diff two files returns a unified diff', async () => {
     const a = join(tmpDir, 'diff_a.txt');
     const b = join(tmpDir, 'diff_b.txt');
@@ -668,13 +720,13 @@ describe('P0 Functional Tests - Tools (MCP Client)', () => {
       arguments: { a, b },
     });
     assert.notStrictEqual(result.isError, true);
-    const structured = result.structuredContent as {
+    const structured = result._meta as {
       linesAdded?: number;
       linesRemoved?: number;
     };
     assert.strictEqual(structured.linesAdded, 1);
     assert.strictEqual(structured.linesRemoved, 1);
-    // The diff itself rides the text content block, not structuredContent.
+    // The diff itself rides the text content block, not _meta.
     const diffText = (result.content as { type: string; text?: string }[])
       .filter((c) => c.type === 'text')
       .map((c) => c.text ?? '')
@@ -710,7 +762,7 @@ describe('P0 Functional Tests - Tools (MCP Client)', () => {
       name: 'list',
       arguments: { path: sub, maxEntries: 2 },
     });
-    const s1 = r1.structuredContent as {
+    const s1 = r1._meta as {
       nextCursor?: string;
       entryCount?: number;
       resourceUri?: string;
@@ -726,9 +778,33 @@ describe('P0 Functional Tests - Tools (MCP Client)', () => {
       name: 'list',
       arguments: { path: sub, maxEntries: 2, cursor: s1.nextCursor },
     });
-    const s2 = r2.structuredContent as { nextCursor?: string; entryCount?: number };
+    const s2 = r2._meta as { nextCursor?: string; entryCount?: number };
     assert.strictEqual(s2.entryCount, 2);
     assert.ok(!s2.nextCursor, 'second page is the last');
+  });
+
+  it('TC-FUNC-075: list text carries nextCursor', async () => {
+    const sub = join(tmpDir, 'cursor_text_dir');
+    await mkdir(sub, { recursive: true });
+    for (let i = 0; i < 4; i++) await writeFile(join(sub, `g${String(i)}.txt`), 'x');
+
+    const first = await harness.client.callTool({
+      name: 'list',
+      arguments: { path: sub, maxEntries: 2 },
+    });
+    const firstText = firstTextBlock(first).text ?? '';
+    const match = /^nextCursor: (\S+)$/m.exec(firstText);
+    assert.ok(match, `first page text should carry a nextCursor line: ${firstText}`);
+    const cursor = match[1];
+    // The model passes back verbatim what it read, so the two must agree.
+    assert.strictEqual(cursor, (first._meta as { nextCursor?: string }).nextCursor);
+
+    const second = await harness.client.callTool({
+      name: 'list',
+      arguments: { path: sub, maxEntries: 2, cursor },
+    });
+    const secondText = firstTextBlock(second).text ?? '';
+    assert.ok(!/^nextCursor: /m.test(secondText), 'last page advertises no next page');
   });
 
   it('TC-FUNC-063b: list pages are stable and query-bound', async () => {
@@ -741,7 +817,7 @@ describe('P0 Functional Tests - Tools (MCP Client)', () => {
       name: 'list',
       arguments: { path: sub, maxEntries: 1 },
     });
-    const firstStructured = first.structuredContent as {
+    const firstStructured = first._meta as {
       entries?: { name: string }[];
       nextCursor?: string;
     };
@@ -754,7 +830,7 @@ describe('P0 Functional Tests - Tools (MCP Client)', () => {
       arguments: { path: sub, maxEntries: 10, cursor },
     });
     assert.notStrictEqual(second.isError, true);
-    const secondStructured = second.structuredContent as { entries?: { name: string }[] };
+    const secondStructured = second._meta as { entries?: { name: string }[] };
     assert.deepStrictEqual(
       [...(firstStructured.entries ?? []), ...(secondStructured.entries ?? [])].map(
         (entry) => entry.name,
@@ -829,7 +905,7 @@ describe('P0 Functional Tests - Tools (MCP Client)', () => {
         arguments: { moves: [{ source: src, destination: dst }], copy: true },
       });
       assert.notStrictEqual(result.isError, true);
-      const s = result.structuredContent as { moves?: unknown[]; skipped?: string[] };
+      const s = result._meta as { moves?: unknown[]; skipped?: string[] };
       assert.strictEqual(s.moves?.length, 0);
       assert.ok(s.skipped?.includes(dst));
       assert.strictEqual(await readFile(dst, 'utf-8'), 'existing dst');
@@ -853,7 +929,7 @@ describe('P0 Functional Tests - Tools (MCP Client)', () => {
         arguments: { moves: [{ source: src, destination: dst }], copy: true },
       });
       assert.notStrictEqual(result.isError, true);
-      const s = result.structuredContent as { moves?: unknown[]; skipped?: string[] };
+      const s = result._meta as { moves?: unknown[]; skipped?: string[] };
       assert.strictEqual(s.moves?.length, 1);
       assert.strictEqual(s.skipped, undefined);
       assert.strictEqual(await readFile(dst, 'utf-8'), 'new source');
@@ -877,7 +953,7 @@ describe('P0 Functional Tests - Tools (MCP Client)', () => {
         arguments: { moves: [{ source: src, destination: dst }] },
       });
       assert.notStrictEqual(result.isError, true);
-      const s = result.structuredContent as { moves?: unknown[]; skipped?: string[] };
+      const s = result._meta as { moves?: unknown[]; skipped?: string[] };
       assert.strictEqual(s.moves?.length, 0);
       assert.ok(s.skipped?.includes(dst));
       assert.strictEqual(await readFile(src, 'utf-8'), 'move me');
@@ -902,7 +978,7 @@ describe('P0 Functional Tests - Tools (MCP Client)', () => {
         arguments: { moves: [{ source: src, destination: dst }] },
       });
       assert.notStrictEqual(result.isError, true);
-      const s = result.structuredContent as { moves?: unknown[]; skipped?: string[] };
+      const s = result._meta as { moves?: unknown[]; skipped?: string[] };
       assert.strictEqual(s.moves?.length, 1);
       assert.strictEqual(s.skipped, undefined);
       assert.strictEqual(await readFile(dst, 'utf-8'), 'move me');
@@ -925,7 +1001,7 @@ describe('P0 Functional Tests - Tools (MCP Client)', () => {
         arguments: { paths: [dir], recursive: true },
       });
       assert.notStrictEqual(result.isError, true);
-      const s = result.structuredContent as {
+      const s = result._meta as {
         results?: { path?: string; value?: { deleted?: boolean }; error?: unknown }[];
         summary?: { failed?: number };
       };
@@ -956,7 +1032,7 @@ describe('P0 Functional Tests - Tools (MCP Client)', () => {
         arguments: { paths: [dir], recursive: true },
       });
       assert.notStrictEqual(result.isError, true);
-      const s = result.structuredContent as {
+      const s = result._meta as {
         results?: { path?: string; value?: { deleted?: boolean } }[];
         summary?: { failed?: number };
       };
@@ -1046,7 +1122,7 @@ describe('P0 Functional Tests - Tools (MCP Client)', () => {
             },
           });
           assert.notStrictEqual(result.isError, true);
-          const s = result.structuredContent as {
+          const s = result._meta as {
             moves?: { from?: string; to?: string }[];
             failures?: { source?: string; error?: { code?: string } }[];
           };
@@ -1101,7 +1177,7 @@ describe('P0 Functional Tests - Tools (MCP Client)', () => {
             },
           });
           assert.notStrictEqual(result.isError, true);
-          const s = result.structuredContent as { moves?: unknown[] };
+          const s = result._meta as { moves?: unknown[] };
           assert.strictEqual(s.moves?.length, 1, 'offered accepted dir is granted');
 
           // secretDir was never offered -> not granted -> read fails ACCESS_DENIED.
@@ -1109,7 +1185,7 @@ describe('P0 Functional Tests - Tools (MCP Client)', () => {
             name: 'read',
             arguments: { path: join(secretDir, 'secret.txt') },
           });
-          const rs = readRes.structuredContent as {
+          const rs = readRes._meta as {
             results?: { error?: { code?: string } }[];
             summary?: { failed?: number };
           };
@@ -1142,7 +1218,7 @@ describe('P0 Functional Tests - Tools (MCP Client)', () => {
       arguments: { pattern: '**/*.txt' },
     });
     assert.notStrictEqual(result.isError, true);
-    const sc = result.structuredContent as { results?: { path: string }[] };
+    const sc = result._meta as { results?: { path: string }[] };
     assert.ok(sc.results?.some((r) => r.path.endsWith('findme.txt')));
   });
 
@@ -1155,7 +1231,7 @@ describe('P0 Functional Tests - Tools (MCP Client)', () => {
       name: 'find_files',
       arguments: { path: dir, pattern: '*.txt', maxResults: 1 },
     });
-    const firstStructured = first.structuredContent as {
+    const firstStructured = first._meta as {
       results?: { path: string }[];
       nextCursor?: string;
       resourceUri?: string;
@@ -1172,7 +1248,7 @@ describe('P0 Functional Tests - Tools (MCP Client)', () => {
       arguments: { path: dir, pattern: '*.txt', maxResults: 10, cursor },
     });
     assert.notStrictEqual(second.isError, true);
-    const secondStructured = second.structuredContent as {
+    const secondStructured = second._meta as {
       results?: { path: string }[];
       resourceUri?: string;
     };
@@ -1262,7 +1338,7 @@ describe('P0 Functional Tests - Tools (MCP Client)', () => {
       arguments: { path: dir, searchPattern: 'NEEDLE_MARK' },
     });
     assert.notStrictEqual(result.isError, true);
-    const structured = result.structuredContent as {
+    const structured = result._meta as {
       matches?: { line?: number; content?: string }[];
       totalMatches?: number;
     };
@@ -1277,7 +1353,7 @@ describe('P0 Functional Tests - Tools (MCP Client)', () => {
       name: 'search_text',
       arguments: { path: file, searchPattern: 'NEEDLE', maxResults: 1 },
     });
-    const firstStructured = first.structuredContent as {
+    const firstStructured = first._meta as {
       matches?: { content: string }[];
       nextCursor?: string;
     };
@@ -1290,7 +1366,7 @@ describe('P0 Functional Tests - Tools (MCP Client)', () => {
       arguments: { path: file, searchPattern: 'NEEDLE', maxResults: 10, cursor },
     });
     assert.notStrictEqual(second.isError, true);
-    const secondStructured = second.structuredContent as { matches?: { content: string }[] };
+    const secondStructured = second._meta as { matches?: { content: string }[] };
     assert.deepStrictEqual(
       [...(firstStructured.matches ?? []), ...(secondStructured.matches ?? [])].map(
         (match) => match.content,
@@ -1317,7 +1393,7 @@ describe('P0 Functional Tests - Tools (MCP Client)', () => {
         name: 'list',
         arguments: { path: join(root, 'http-pages'), maxEntries: 1 },
       });
-      const firstStructured = first.structuredContent as { nextCursor?: string };
+      const firstStructured = first._meta as { nextCursor?: string };
       const cursor = firstStructured.nextCursor;
       assert.ok(cursor);
 
@@ -1326,7 +1402,7 @@ describe('P0 Functional Tests - Tools (MCP Client)', () => {
         arguments: { path: join(root, 'http-pages'), maxEntries: 10, cursor },
       });
       assert.notStrictEqual(second.isError, true);
-      const secondStructured = second.structuredContent as { entries?: { name: string }[] };
+      const secondStructured = second._meta as { entries?: { name: string }[] };
       assert.deepStrictEqual(
         secondStructured.entries?.map((entry) => entry.name),
         ['charlie.txt'],
@@ -1356,34 +1432,15 @@ describe('P0 Functional Tests - Tools (MCP Client)', () => {
       );
     }
 
-    // Only the three tools whose result shape is a union still publish an
-    // outputSchema; the rest return a flat object their description names.
-    for (const name of ['create', 'patch', 'stat']) {
-      const tool = tools.find((t) => t.name === name);
-      assert.ok(tool, `${name} must be registered`);
-      assert.strictEqual(tool.outputSchema, undefined, `${name} must not publish an outputSchema`);
-    }
-
-    for (const name of ['edit']) {
-      const tool = tools.find((t) => t.name === name);
-      assert.ok(tool, `${name} must be registered`);
-      const serialized = JSON.stringify(tool.outputSchema);
+    // No tool publishes an outputSchema any more. Publishing one obliges the
+    // result to carry structuredContent, and every tool that used to publish
+    // (read, edit, delete, replace_text) authors its own text and now ships its
+    // metadata under _meta instead — the two are mutually exclusive.
+    for (const tool of tools) {
       assert.strictEqual(
-        (tool.outputSchema as { $defs?: unknown }).$defs,
+        tool.outputSchema,
         undefined,
-        `${name} outputSchema must be dereferenced (no $defs)`,
-      );
-      assert.ok(
-        serialized.includes('"format":"date-time"'),
-        `${name} must keep the date-time format keyword inline`,
-      );
-      // Use-site guard: `02-29` is the leap-day branch unique to zod's calendar
-      // regex. Asserting over the whole serialized schema is what catches a
-      // mechanism that relocates the regex to each use site instead of
-      // removing it.
-      assert.ok(
-        !serialized.includes('02-29'),
-        `${name} must not carry the calendar regex at any use site`,
+        `${tool.name} must not publish an outputSchema`,
       );
     }
 

--- a/docs/plan/2026-09-05-text-first-results/text-first-results.plan-hunt.md
+++ b/docs/plan/2026-09-05-text-first-results/text-first-results.plan-hunt.md
@@ -1,0 +1,151 @@
+# Plan hunt: [`text-first-results.plan.md`](text-first-results.plan.md)
+
+Hunted 2026-09-05 against commit `a7aa52d0`.
+
+> **Resolved 2026-09-05.** All three confirmed findings were fixed in the plan:
+> `failedSummary` added to Scope and the inventory with the repoint in step 2;
+> `stat`'s text removal folded into step 1 and the old step 5 deleted (steps
+> renumbered, 7 → 6); step 3's example corrected and the tail trailer keyed on
+> `linesRead`. Not re-hunted — the plan has not been executed since.
+
+**Drift**: none. `git diff --stat a7aa52d0..HEAD` over the plan's watched paths
+is empty; every one of the 19 cited paths resolves under `git ls-files`.
+
+**Baseline confirmed**: `node scripts/tasks.mjs test` → `tests 271 / pass 271 /
+fail 0`, matching the plan's stated baseline.
+
+**Excerpts checked**: every `Current state` location was opened. All code
+excerpts match. Line anchors are exact at
+[`define.ts:95-99`](../../../src/tools/define.ts#L95-L99),
+[`:556`](../../../src/tools/define.ts#L556),
+[`read.ts:159`](../../../src/tools/read.ts#L159),
+[`:303`](../../../src/tools/read.ts#L303),
+[`:308-310`](../../../src/tools/read.ts#L308-L310),
+[`:397`](../../../src/tools/read.ts#L397),
+[`list.ts:160`](../../../src/tools/list.ts#L160),
+[`:384-393`](../../../src/tools/list.ts#L384-L393),
+[`stat.ts:8`](../../../src/tools/stat.ts#L8),
+[`:248-276`](../../../src/tools/stat.ts#L248-L276),
+[`edit.ts:528-529`](../../../src/tools/edit.ts#L528-L529),
+[`delete-file.ts:421-423`](../../../src/tools/delete-file.ts#L421-L423),
+[`instructions.ts:72-73`](../../../src/instructions.ts#L72-L73).
+
+3 findings confirmed, 2 candidates killed.
+
+## Confirmed
+
+### 1. `failedSummary` breaks six assertions in two unlisted files — steps 1, 2
+
+Step 1 routes `read`'s structured half to `_meta`.
+[`__tests__/helpers.ts:495-501`](../../../__tests__/helpers.ts#L495-L501)
+exports a helper that reads the old field:
+
+```ts
+export function failedSummary(result: { structuredContent?: unknown }):
+  ...
+  return result.structuredContent as
+```
+
+The parameter is optional, so this keeps type-checking and returns `undefined`
+silently. Six live call sites pass `read` results through it:
+[`tools.test.ts:392`](../../../__tests__/tools.test.ts#L392) (TC-FUNC-015),
+[`:419`](../../../__tests__/tools.test.ts#L419) (TC-FUNC-017),
+[`:439`](../../../__tests__/tools.test.ts#L439) (TC-FUNC-021),
+[`:481`](../../../__tests__/tools.test.ts#L481),
+[`:493`](../../../__tests__/tools.test.ts#L493), and
+[`http-transport.test.ts:73`](../../../__tests__/http-transport.test.ts#L73)
+(HTTP-004).
+
+`read` returns `text` unconditionally — including the all-paths-failed case at
+[`read.ts:514-520`](../../../src/tools/read.ts#L514-L520) — and a total batch
+failure still routes through `buildSuccessResponse`, so no result shape escapes.
+
+Three consequences:
+
+- Step 1's Verify is false: "failures only in the assertions listed under
+  Current state ... **nothing else**". These six are not listed — the
+  inventory at plan lines 106-128 enumerates only the *literal*
+  `structuredContent` occurrences, and these read the field through the helper.
+- Step 2's Verify (`fail 0`) is unreachable. Step 2 is scoped "at every line
+  listed under Current state", so it never touches them.
+- The Done gate "`git status` shows no modified files outside the in-scope
+  list" cannot hold: the fix touches
+  [`__tests__/helpers.ts`](../../../__tests__/helpers.ts) and
+  [`__tests__/http-transport.test.ts`](../../../__tests__/http-transport.test.ts),
+  neither of which appears in the in-scope *or* out-of-scope list.
+
+**Fix belongs to the author**: add both files to Scope, add the six sites to
+the Current state inventory, and have step 2 repoint `failedSummary` to
+`result._meta`.
+
+### 2. `stat` drops its text too late — steps 2, 3, 4 gates unreachable
+
+[`stat.ts:248`](../../../src/tools/stat.ts#L248) computes `text` and
+[`:271`](../../../src/tools/stat.ts#L271) returns it, unconditionally. Step 1's
+`hasText` branch therefore sends `stat`'s object to `_meta` and leaves
+`structuredContent` undefined — from step 1 until step 5 removes the text.
+
+Step 2 instructs: "Leave the stat cases ... as they are." Those four assertions
+then throw or fail for three consecutive steps:
+[`tools.test.ts:1206`](../../../__tests__/tools.test.ts#L1206),
+[`:1226`](../../../__tests__/tools.test.ts#L1226),
+[`:1247`](../../../__tests__/tools.test.ts#L1247) (all inside
+`TC-FUNC-015s`, dereferencing `sc.results?.[0]?.value` on `undefined`), and
+[`inspector-stdio.test.ts:215`](../../../__tests__/inspector-stdio.test.ts#L215).
+
+Steps 2, 3 and 4 each demand `fail 0`. A cold executor stops at step 2's Verify
+under the plan's own STOP: "A step's verification fails twice after one fix
+attempt."
+
+**Fix belongs to the author**: reorder — make the current step 5 (`stat`: drop
+the lossy text summary) part of step 1, or move it directly after it, and
+renumber the expected pass counts accordingly.
+
+### 3. Step 3's worked example and tail sub-clause are unreachable — step 3
+
+`totalLines` is assigned in exactly one place,
+[`core/read.ts:669-677`](../../../src/core/read.ts#L669-L677) (`readFull`), and
+that same object literal pins `hasMoreLines: false`. The three modes that can
+set `hasMoreLines: true` — `readHead`, `readRange`, `readTail` — never set
+`totalLines`, and nothing enriches it downstream.
+
+Two halves of step 3 rest on it:
+
+- **The worked example cannot be produced.**
+  [`read.ts:179-182`](../../../src/tools/read.ts#L179-L182) always falls to
+  `'File was truncated. Read next chunk with these args.'`, so a trailer built
+  from `continuation.hint` can never read `4800 lines remain (201-5000)` as the
+  step's example shows. The *format* survives and `TC-FUNC-074` still passes —
+  its regex wildcards the hint with `.*` — so this misleads the executor
+  without failing a gate.
+- **The tail sub-clause is dead.** "emit `// truncated: showing last N of
+  <totalLines> lines` for that case when `totalLines` is known" — never known
+  for a tail read, so the `otherwise nothing` arm always wins. Combined with
+  [`read.ts:308-310`](../../../src/tools/read.ts#L308-L310) suppressing
+  `continuation` for tail, a truncated `tail` read emits no trailer at all and
+  the model loses its only in-text signal that lines remain.
+
+**Fix belongs to the author**: correct the example to the hint the code emits,
+and either state plainly that tail gets no trailer, or emit
+`// truncated: showing last <linesRead> lines` from `linesRead`, which tail
+does populate.
+
+## Killed
+
+Reported for the record; neither is a defect.
+
+- **`read.ts:394-397` deletion range.** The step names its target in prose
+  ("the `publishOutputSchema: true` line and its comment"), and `:394` is
+  neither. The plan pins `:397` independently under Current state, and step 1's
+  own `--quick` gate compiles, so a mis-deletion of `output:` fails inside the
+  step.
+- **`tools.test.ts:1358-1380` citation for `TOOL-SURFACE-001`.** The range
+  holds exactly what the bullet claims it holds; the bullet never says the test
+  begins there, and it carries no excerpt for the STOP condition to mismatch.
+  Step 2's own `1367-1388` is the exact block boundary.
+
+## Verdict
+
+**REQUEST_CHANGES** — 3 confirmed defects, 2 of them dead gates that halt a
+cold executor at step 2. Back to `write-plan`; re-hunt or proceed after the
+fixes. Do not hand this to `run-plan` as it stands.

--- a/docs/plan/2026-09-05-text-first-results/text-first-results.plan.md
+++ b/docs/plan/2026-09-05-text-first-results/text-first-results.plan.md
@@ -1,0 +1,544 @@
+# Plan: Text-shaped tool results reach the model as text in Claude Code
+
+> **Executor rules**: work the steps in order. Run every Verify command and
+> confirm its expected result before moving on. On any STOP condition, stop and
+> report the condition, the step, and the evidence.
+>
+> **Written against** commit `a7aa52d0`, 2026-09-05.
+> **Drift check (run first)**: `git diff --stat a7aa52d0..HEAD -- src/tools/define.ts src/tools/read.ts src/tools/list.ts src/tools/stat.ts src/tools/edit.ts src/tools/delete-file.ts src/core/read.ts src/instructions.ts __tests__/`
+> Its file list is what narrows the excerpt match: compare
+> [Current state](#current-state) against the live code for every file it flags.
+> A mismatch is a [STOP](#stop) condition.
+
+## Goal
+
+Claude Code (verified on 2.1.261) drops every `text` content block from an MCP
+tool result whenever `structuredContent` is present, and shows the model
+`JSON.stringify(structuredContent)` instead. Eight tools here supply a
+model-facing `text` (file bytes, ASCII tree, unified diff, one-line summaries)
+and a metadata-only `structuredContent`. In Claude Code the model therefore
+never sees the file a `read` returned, nor the tree from `list`, and falls back
+to one `resources/read` round trip per file. Measured in session
+`768724c4-a9f9-47dd-bd5b-ecb93d4c03aa`: 3 dead `read` calls, 14 fallback
+resource reads, `list` at 3.9x the size of its tree.
+
+After this lands, a tool that supplies `text` ships its structured half under
+`_meta` instead of `structuredContent`. Claude Code then renders the text
+(verified by a headless run against a patched `dist/`), programmatic clients
+still get the metadata, and the two facts the model needs from that metadata
+(read continuation, list `nextCursor`) ride in the text as a trailer.
+
+Requirements covered: none, this is a fix.
+
+## Current state
+
+- [`src/tools/define.ts:250-264`](../../../src/tools/define.ts#L250-L264) —
+  the one place every success result is assembled. Its comment states the
+  assumption Claude Code breaks:
+
+  ```ts
+  /**
+   * The spec asks a structured result to *also* carry the JSON as a text block,
+   * for clients that read only `content`. Where a tool supplies its own `text`
+   * (list's ASCII tree, read's file) that serves such a client better, so it
+   * wins; tools with no `text` still fall back to the JSON.
+   */
+  function buildSuccessResponse<O>(result: RunResult<O>): CallToolResult {
+    const text = result.text ?? JSON.stringify(result.structured);
+    const content: ContentBlock[] = [{ type: 'text' as const, text }, ...(result.resources ?? [])];
+    return {
+      content,
+      structuredContent: result.structured,
+      ...(isTotalBatchFailure(result.structured) ? { isError: true } : {}),
+    };
+  }
+  ```
+
+- [`src/tools/define.ts:95-99`](../../../src/tools/define.ts#L95-L99) —
+  `RunResult<T>` is `{ structured: T; text?: string; resources?: ContentBlock[] }`.
+  `text` present is the exact signal "this tool authored a model-facing text".
+  **Thirteen** tools supply it. Verify the list before trusting it — a grep for
+  a `text:` property finds only eight, because five build the key as
+  `const text = ...` and return `{ structured, text }`. Use
+  `grep -nE "text[,:}]" src/tools/*.ts`:
+
+  | Tool                     | Supplies `text` at                                                           | After this plan |
+  | :----------------------- | :--------------------------------------------------------------------------- | :-------------- |
+  | `read`                   | [`read.ts:540`](../../../src/tools/read.ts#L540)                              | `_meta`         |
+  | `list`                   | [`list.ts:389`](../../../src/tools/list.ts#L389)                              | `_meta`         |
+  | `diff`                   | [`diff.ts:97`](../../../src/tools/diff.ts#L97)                                | `_meta`         |
+  | `patch`                  | [`patch.ts:158,183`](../../../src/tools/patch.ts#L158)                        | `_meta`         |
+  | `edit`                   | [`edit.ts:584`](../../../src/tools/edit.ts#L584)                              | `_meta`         |
+  | `delete`                 | [`delete-file.ts:452,461`](../../../src/tools/delete-file.ts#L452)            | `_meta`         |
+  | `move`                   | [`move.ts:461`](../../../src/tools/move.ts#L461)                              | `_meta`         |
+  | `replace_text`           | [`replace-in-files.ts:691,693`](../../../src/tools/replace-in-files.ts#L691)  | `_meta`         |
+  | `search_text`            | [`search-content.ts:467`](../../../src/tools/search-content.ts#L467)          | `_meta`         |
+  | `find_files`             | [`search-files.ts:248`](../../../src/tools/search-files.ts#L248)              | `_meta`         |
+  | `stat`                   | [`stat.ts:271`](../../../src/tools/stat.ts#L271)                              | text dropped    |
+  | `create`                 | [`create.ts:165,168`](../../../src/tools/create.ts#L165)                      | text dropped    |
+  | `list_roots`             | [`roots.ts:34`](../../../src/tools/roots.ts#L34)                              | text dropped    |
+
+  The three in the last group are **data tools**: their `text` is a lossy
+  one-line summary of a result whose value is the metadata (`stat`'s
+  `tokenEstimate`, `create`'s per-path outcome, `list_roots`' roots). Dropping
+  it lets `define.ts` render the JSON and keeps `structuredContent`, which is
+  what a caller of those three actually wants. Every other tool's `text` is the
+  document itself, so it stays and the metadata moves to `_meta`.
+
+  `auth_probe` ([`tools.test.ts:287`](../../../__tests__/tools.test.ts#L287)) is
+  a test-local tool that supplies no `text`; it keeps `structuredContent` and
+  needs no change.
+
+- [`src/tools/define.ts:556-563`](../../../src/tools/define.ts#L556-L563) —
+  `outputSchema` reaches the wire only when `publishOutputSchema` is set. Per
+  MCP, a tool that publishes `outputSchema` must return `structuredContent`;
+  Claude Code enforces it (`Output validation error: Tool read has an output
+  schema but no structuredContent`, observed). Publishers today:
+  [`read.ts:397`](../../../src/tools/read.ts#L397),
+  [`edit.ts:529`](../../../src/tools/edit.ts#L529),
+  [`delete-file.ts:423`](../../../src/tools/delete-file.ts#L423),
+  [`replace-in-files.ts:664`](../../../src/tools/replace-in-files.ts#L664).
+  **All four supply `text`**, so all four lose the line — after this plan no
+  tool publishes an `outputSchema` at all.
+
+- [`src/tools/read.ts:514-546`](../../../src/tools/read.ts#L514-L546) — text
+  assembly. Single path: bare file content. Batch: `// <path>` header per
+  file, blank line between. `structuredResults` strips `content` and keeps
+  `continuation`, `totalLines`, `linesRead`, `hasMoreLines`, `contentHash`,
+  `resourceUri`. None of those reach the text today.
+
+- [`src/tools/read.ts:159-189`](../../../src/tools/read.ts#L159-L189) —
+  `buildReadContinuation()` returns `{ tool: 'read', args: { path, startLine,
+  endLine }, hint }`. `hint` has two forms
+  ([`:180-182`](../../../src/tools/read.ts#L180-L182)), but only one is
+  reachable: `totalLines` is assigned in exactly one place,
+  [`core/read.ts:669-677`](../../../src/core/read.ts#L669-L677) (`readFull`),
+  whose same object literal pins `hasMoreLines: false`. The three modes that
+  can set `hasMoreLines: true` — `readHead`, `readRange`, `readTail` — never
+  set `totalLines`, and nothing enriches it downstream. So a continuation's
+  `hint` is **always** `File was truncated. Read next chunk with these args.`;
+  the `N lines remain (a-b)` form never fires. Step 3 must not illustrate it.
+  `linesRead` *is* populated in every mode.
+
+- [`src/tools/read.ts:303-340`](../../../src/tools/read.ts#L303-L340) —
+  `buildPerPathReadValue()` is where `continuation` and `contentHash` are
+  computed per path; `PerPathReadValue` carries them alongside `content`.
+
+- [`src/tools/list.ts:263-279`](../../../src/tools/list.ts#L263-L279) —
+  `listOutput()` puts `nextCursor` and `resourceUri` in the structured half only.
+  [`list.ts:384-393`](../../../src/tools/list.ts#L384-L393) returns
+  `{ structured, text: markdown, resources? }`; `markdown` is the tree from
+  `renderMarkdown()` at [`list.ts:160`](../../../src/tools/list.ts#L160).
+
+- [`src/tools/stat.ts:248-276`](../../../src/tools/stat.ts#L248-L276) — `text`
+  is a lossy one-liner per path (`AGENTS.md: file, 751 B`); the structured half
+  carries `tokenEstimate`, `modified`, `mimeType`, `isHidden`. For the model the
+  JSON is the useful view, so `stat` is treated as a data tool: its `text` is
+  removed and `define.ts` falls back to the JSON text. `stat` supplies `text`
+  **unconditionally** ([`:271`](../../../src/tools/stat.ts#L271)), so step 1
+  would flip it to `_meta` and break four stat assertions the moment it lands.
+  That is why dropping the text is part of step 1 and not a later step.
+
+- [`src/instructions.ts:72-73`](../../../src/instructions.ts#L72-L73) — server
+  instructions say `When a tool returns resourceUri, call resources/read` and
+  `nextCursor is backed by a snapshot`. Both stay true; wording must say where
+  they now appear (text trailer / `_meta` / `resource_link`).
+
+- Tests asserting `structuredContent` on text-supplying tools (all become
+  `_meta`):
+  [`tools.test.ts:100`](../../../__tests__/tools.test.ts#L100) read,
+  [`:406`](../../../__tests__/tools.test.ts#L406) delete,
+  [`:464`](../../../__tests__/tools.test.ts#L464) read,
+  [`:671`](../../../__tests__/tools.test.ts#L671) diff,
+  [`:713,729,744,757`](../../../__tests__/tools.test.ts#L713) list,
+  [`:832,856,880,905`](../../../__tests__/tools.test.ts#L832) move,
+  [`:928,959`](../../../__tests__/tools.test.ts#L928) delete,
+  [`:1049,1104`](../../../__tests__/tools.test.ts#L1049) move,
+  [`:1112`](../../../__tests__/tools.test.ts#L1112) read,
+  [`:1206,1226,1247`](../../../__tests__/tools.test.ts#L1206) stat — stays
+  `structuredContent` (stat no longer supplies text),
+  [`:1320,1329`](../../../__tests__/tools.test.ts#L1320) list;
+  [`stdio.test.ts:128,137`](../../../__tests__/stdio.test.ts#L128) list;
+  [`http-server.test.ts:79-81`](../../../__tests__/http-server.test.ts#L79) diff;
+  [`subscriptions-listen.test.ts:435-436`](../../../__tests__/subscriptions-listen.test.ts#L435) diff;
+  [`inspector-stdio.test.ts:199-215`](../../../__tests__/inspector-stdio.test.ts#L199) stat — stays;
+  [`inspector-stdio.test.ts:277-299`](../../../__tests__/inspector-stdio.test.ts#L277) — read
+  through the Inspector CLI, `structuredContent.results[0].error.code` becomes
+  `_meta.results[0].error.code`.
+  [`tools.test.ts:788`](../../../__tests__/tools.test.ts#L788) asserts
+  `structuredContent === undefined` on an *error* result and is untouched.
+
+- Tests that read `structuredContent` **through a helper**, so they do not
+  appear in a grep for the field.
+  [`__tests__/helpers.ts:495-501`](../../../__tests__/helpers.ts#L495-L501):
+
+  ```ts
+  /** Structured per-path failure summary from a read/search tool result. */
+  export function failedSummary(result: { structuredContent?: unknown }):
+  ...
+    return result.structuredContent as
+  ```
+
+  The parameter is optional, so repointing the tools without repointing this
+  keeps compiling and returns `undefined` at run time. Six live call sites, all
+  on `read` results — `read` supplies `text` on every path, including the
+  all-paths-failed one
+  ([`read.ts:514-520`](../../../src/tools/read.ts#L514-L520)), so no result
+  shape escapes:
+  [`tools.test.ts:392`](../../../__tests__/tools.test.ts#L392) TC-FUNC-015,
+  [`:419`](../../../__tests__/tools.test.ts#L419) TC-FUNC-017,
+  [`:439`](../../../__tests__/tools.test.ts#L439) TC-FUNC-021,
+  [`:481`](../../../__tests__/tools.test.ts#L481),
+  [`:493`](../../../__tests__/tools.test.ts#L493),
+  [`http-transport.test.ts:73`](../../../__tests__/http-transport.test.ts#L73)
+  HTTP-004.
+
+- [`__tests__/tools.test.ts:1358-1380`](../../../__tests__/tools.test.ts#L1358-L1380)
+  — `TOOL-SURFACE-001` pins which tools publish `outputSchema`: asserts
+  `create`, `patch`, `stat` do not, and inspects `edit`'s. Must be re-pinned.
+
+- Conventions: batch text tokens joined with ` · ` as in
+  [`edit.ts:489-515`](../../../src/tools/edit.ts#L489-L515); every tool test is
+  an `it('TC-FUNC-NNN: ...')` inside
+  [`tools.test.ts`](../../../__tests__/tools.test.ts) using
+  `harness.client.callTool` and `firstTextBlock(result)`.
+
+- Verified facts this plan rests on (headless `claude -p --mcp-config` runs
+  against a temporarily patched `dist/tools/define.js`, 2026-09-05):
+  - `structuredContent` present ⇒ model sees JSON only, links kept.
+  - `structuredContent` absent, `_meta` carries the same object ⇒ model sees
+    the text blocks verbatim; `_meta` is not shown to the model.
+  - `outputSchema` published without `structuredContent` ⇒ client-side error.
+
+## Commands
+
+| Purpose            | Command                              | Expected on success                      |
+| ------------------ | ------------------------------------ | ---------------------------------------- |
+| Static checks      | `node scripts/tasks.mjs --quick`     | ends `All matched files use Prettier code style!`, exit 0 |
+| Tests              | `node scripts/tasks.mjs test`        | `ℹ pass 271` (+ new), `ℹ fail 0`         |
+| Full gate          | `node scripts/tasks.mjs`             | exit 0                                   |
+| Build for CC probe | `npm run build`                      | exit 0, `dist/tools/define.js` updated   |
+
+Baseline at `a7aa52d0`: quick check passes, `tests 271 / pass 271 / fail 0`.
+
+## Scope
+
+**In scope** — the only files to modify:
+
+- [`src/tools/define.ts`](../../../src/tools/define.ts)
+- [`src/tools/read.ts`](../../../src/tools/read.ts)
+- [`src/tools/list.ts`](../../../src/tools/list.ts)
+- [`src/tools/stat.ts`](../../../src/tools/stat.ts)
+- [`src/tools/create.ts`](../../../src/tools/create.ts) — data tool: text dropped
+- [`src/tools/roots.ts`](../../../src/tools/roots.ts) — data tool: text dropped
+- [`src/tools/edit.ts`](../../../src/tools/edit.ts) (one line)
+- [`src/tools/delete-file.ts`](../../../src/tools/delete-file.ts) (one line)
+- [`src/tools/replace-in-files.ts`](../../../src/tools/replace-in-files.ts) (one line)
+- [`src/instructions.ts`](../../../src/instructions.ts)
+- [`__tests__/tools.test.ts`](../../../__tests__/tools.test.ts)
+- [`__tests__/helpers.ts`](../../../__tests__/helpers.ts) (one line)
+- [`__tests__/http-transport.test.ts`](../../../__tests__/http-transport.test.ts)
+  — only if the `failedSummary` signature change leaves it uncompiling; the
+  one-line helper fix should cover its single call site untouched.
+- [`__tests__/stdio.test.ts`](../../../__tests__/stdio.test.ts)
+- [`__tests__/http-server.test.ts`](../../../__tests__/http-server.test.ts)
+- [`__tests__/subscriptions-listen.test.ts`](../../../__tests__/subscriptions-listen.test.ts)
+- [`__tests__/inspector-stdio.test.ts`](../../../__tests__/inspector-stdio.test.ts)
+- [`CHANGELOG.md`](../../../CHANGELOG.md)
+
+**Files out of scope** — leave alone even though they look related:
+
+- [`src/tools/search-content.ts`](../../../src/tools/search-content.ts),
+  [`search-files.ts`](../../../src/tools/search-files.ts) — both supply `text`
+  and publish no `outputSchema`, so the `define.ts` rule moves them to `_meta`
+  with no per-tool edit. Their *tests* are in scope (step 2).
+- [`src/tools/diff.ts`](../../../src/tools/diff.ts),
+  [`patch.ts`](../../../src/tools/patch.ts),
+  [`move.ts`](../../../src/tools/move.ts) — already supply `text`; the
+  `define.ts` rule covers them with no per-tool edit.
+- [`src/core/file-uri.ts`](../../../src/core/file-uri.ts) — the
+  `resource_link` `audience` annotation is irrelevant: Claude Code renders every
+  link as `[Resource link: NAME] URI` regardless of audience (verified in the
+  2.1.261 binary). Do not touch.
+- [`package.json`](../../../package.json), [`server.json`](../../../server.json)
+  — versions are bumped by the Release workflow only.
+- [`README.md`](../../../README.md) — does not document result shapes.
+
+## Steps
+
+### 1. Route the structured half to `_meta`, and drop `stat`'s text
+
+In [`define.ts:256-264`](../../../src/tools/define.ts#L256-L264) replace the
+body of `buildSuccessResponse` so `structuredContent` is emitted only when the
+tool supplied no `text`; otherwise the same object goes under `_meta`:
+
+```ts
+function buildSuccessResponse<O>(result: RunResult<O>): CallToolResult {
+  const hasText = result.text !== undefined;
+  const text = result.text ?? JSON.stringify(result.structured);
+  const content: ContentBlock[] = [{ type: 'text' as const, text }, ...(result.resources ?? [])];
+  return {
+    content,
+    ...(hasText
+      ? { _meta: result.structured as Record<string, unknown> }
+      : { structuredContent: result.structured }),
+    ...(isTotalBatchFailure(result.structured) ? { isError: true } : {}),
+  };
+}
+```
+
+Replace the doc comment above it with the fact: Claude Code (and any client
+that treats `structuredContent` as the canonical model view) discards `text`
+blocks when `structuredContent` is present, so a tool that authored a text
+result ships its metadata under `_meta` instead. Leave `isTotalBatchFailure`
+and `completeProgress(result.structured)` untouched; both read the in-memory
+`structured`, not the wire field.
+
+Remove the `publishOutputSchema: true` line and its comment at
+[`read.ts:394-397`](../../../src/tools/read.ts#L394-L397),
+[`edit.ts:528-529`](../../../src/tools/edit.ts#L528-L529),
+[`delete-file.ts:421-423`](../../../src/tools/delete-file.ts#L421-L423), and
+[`replace-in-files.ts:664`](../../../src/tools/replace-in-files.ts#L664). All
+four supply `text`, so all four would otherwise publish an `outputSchema` while
+returning no `structuredContent` — the error the Goal cites. No tool publishes
+one after this.
+
+Then make the three data tools, in this same step — delete each one's `text`
+computation and the `text,` key in its return, so `define.ts` falls back to the
+JSON and each keeps `structuredContent`:
+
+- [`stat.ts:248-276`](../../../src/tools/stat.ts#L248-L276). Also remove the
+  `formatBytes` import at [`stat.ts:8`](../../../src/tools/stat.ts#L8); line
+  257 is its only use.
+- [`create.ts:165,168`](../../../src/tools/create.ts#L165) — both return sites,
+  and whatever builds `summary` if nothing else uses it.
+- [`roots.ts:28-34`](../../../src/tools/roots.ts#L28-L34) — the `const text =`
+  ternary and the `text` key in `Promise.resolve({ structured, text })`.
+
+> These cannot wait for a later step. All three supply `text`
+> unconditionally, so the moment the `define.ts` rule lands they ship `_meta`
+> and the assertions steps 2-4 are told to leave alone start failing — making
+> every `fail 0` gate between here and there unreachable. This is what the
+> 2026-09-05 run hit; see [`text-first-results.run.md`](text-first-results.run.md).
+
+**Verify**: `node scripts/tasks.mjs --quick` → exit 0 (lint catches the unused
+`formatBytes` import if it was missed).
+`node scripts/tasks.mjs test` → failures only in the assertions listed under
+Current state for read, delete, diff, list, move, `find_files` and
+`search_text` — including the six `failedSummary` sites — and in
+`TOOL-SURFACE-001`; nothing else.
+
+These must **still pass**; each failure names the data-tool edit that was
+missed:
+
+| Failing test                                          | Means      |
+| :---------------------------------------------------- | :--------- |
+| `TC-FUNC-015s`, `INSP-STDIO-002`                       | `stat`     |
+| `SMOKE-004`, `TC-FUNC-052`, `INSP-CFG-002`, `INSP-STDIO-004` | `list_roots` |
+| any `create` case                                      | `create`   |
+| `TC-FUNC-013r`                                         | `replace_text` still publishes `outputSchema` |
+
+### 2. Repoint tests from `structuredContent` to `_meta`
+
+Mechanical: at every line listed under Current state for read, delete, diff,
+list, move (not stat), change `result.structuredContent` to `result._meta`
+(the SDK client passes `_meta` through on `CallToolResult`). Same change at the
+`find_files` and `search_text` sites, which the Current state inventory missed
+because both tools were mis-classified:
+[`tools.test.ts:1145`](../../../__tests__/tools.test.ts#L1145),
+[`:1158`](../../../__tests__/tools.test.ts#L1158),
+[`:1175`](../../../__tests__/tools.test.ts#L1175) find_files;
+[`:1265`](../../../__tests__/tools.test.ts#L1265),
+[`:1280`](../../../__tests__/tools.test.ts#L1280),
+[`:1293`](../../../__tests__/tools.test.ts#L1293) search_text.
+`replace_text` needs none — `TC-FUNC-013r` asserts only `isError` and the file
+on disk. In
+[`inspector-stdio.test.ts:277-299`](../../../__tests__/inspector-stdio.test.ts#L277-L299)
+change the `executeInspectorCli<{ structuredContent?: ... }>` generic and the
+read at `:298` to `_meta`. Leave the stat cases
+([`tools.test.ts:1206,1226,1247`](../../../__tests__/tools.test.ts#L1206),
+[`inspector-stdio.test.ts:199-215`](../../../__tests__/inspector-stdio.test.ts#L199))
+and [`tools.test.ts:788`](../../../__tests__/tools.test.ts#L788) as they are.
+Leave the `list_roots` sites too — it is a data tool now:
+[`tools.test.ts:499`](../../../__tests__/tools.test.ts#L499),
+[`smoke.test.ts:49`](../../../__tests__/smoke.test.ts#L49),
+[`inspector-config.test.ts:59,74`](../../../__tests__/inspector-config.test.ts#L59),
+[`inspector-stdio.test.ts:114,129`](../../../__tests__/inspector-stdio.test.ts#L114).
+Same for `auth_probe` at
+[`tools.test.ts:338,359`](../../../__tests__/tools.test.ts#L338).
+
+Repoint the helper too — one line at
+[`helpers.ts:501`](../../../__tests__/helpers.ts#L501), `result.structuredContent`
+to `result._meta`, and the parameter type at
+[`:495`](../../../__tests__/helpers.ts#L495) to `{ _meta?: unknown }`. That
+covers all six call sites (five in `tools.test.ts`, one in
+`http-transport.test.ts`) without touching them. `failedSummary` is only ever
+handed `read` results, so no caller needs the old field back; the parameter is
+optional, so leaving it would compile and fail six assertions at run time
+instead.
+
+In `TOOL-SURFACE-001`
+([`tools.test.ts:1358-1380`](../../../__tests__/tools.test.ts#L1358-L1380)):
+replace the `['create', 'patch', 'stat']` loop with one over **every** tool —
+no tool publishes an `outputSchema` any more, so iterate `tools` directly and
+assert `tool.outputSchema === undefined` for each. Then delete the whole
+`for (const name of ['edit'])` block
+([`tools.test.ts:1367-1388`](../../../__tests__/tools.test.ts#L1367-L1388):
+`$defs`, `date-time`, `02-29` assertions) — with no publishers left it would
+assert on nothing. Update the comment above the loop; it currently says "Only
+the three tools whose result shape is a union still publish an outputSchema".
+
+Add one test beside `TC-FUNC-060` in
+[`tools.test.ts`](../../../__tests__/tools.test.ts) — `TC-FUNC-073: text
+tools ship metadata under _meta, data tools under structuredContent`: call
+`read` on a small file and `stat` on the same file; assert the read result has
+`structuredContent === undefined` and `_meta.summary.succeeded === 1`, and the
+stat result has `_meta === undefined` and
+`structuredContent.summary.succeeded === 1`.
+
+> `stat` is the data-tool half, not `find_files` — `find_files` supplies `text`
+> and is a `_meta` tool. Picking a text tool for this half is the mistake the
+> 2026-09-05 run caught.
+
+**Verify**: `node scripts/tasks.mjs test` → `ℹ pass 272`, `ℹ fail 0`.
+
+### 3. `read`: continuation and hash trailer in the text
+
+In [`read.ts:514-528`](../../../src/tools/read.ts#L514-L528), after the
+per-path text is chosen, append a trailer for any path whose value carries
+`continuation` or `contentHash`. One line each, `//` prefixed, separated from
+the content by a blank line so it cannot be mistaken for file bytes:
+
+```text
+<file content>
+
+// truncated: File was truncated. Read next chunk with these args. Continue: read {"path":"C:/x/big.ts","startLine":201,"endLine":400}
+// sha256: 3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+```
+
+Build the first line from `continuation.hint` and
+`JSON.stringify(continuation.args)`; build the second from `contentHash`. For
+the batch shape, place each file's trailer directly under that file's content,
+before the blank line that precedes the next `// <path>` header.
+
+> The hint above is the only one the code emits. Do not write the
+> `N lines remain (a-b)` form into an expected output anywhere — see the
+> `read.ts:159-189` bullet under [Current state](#current-state) for why that
+> branch never fires. Changing `buildReadContinuation` to make it fire is out
+> of scope.
+
+A `tail` read sets `hasMoreLines` but gets no `continuation`
+([`read.ts:308-310`](../../../src/tools/read.ts#L308-L310)), so the rule above
+leaves a truncated tail read with no trailer at all — the model loses its only
+in-text signal that lines were dropped. Cover it with one more line, keyed on
+`hasMoreLines` where `continuation` is absent, built from `linesRead` (which
+every mode populates, unlike `totalLines`):
+
+```text
+// truncated: showing last 20 lines
+```
+
+Add `TC-FUNC-074: read trailer carries continuation and hash` next to
+`TC-FUNC-073`: write a 30-line file, call `read` with `head: 10,
+includeHash: true`, assert `firstTextBlock(result).text` matches
+`/^\/\/ truncated: .*"startLine":11,"endLine":20\}$/m` and
+`/^\/\/ sha256: [0-9a-f]{64}$/m`, and that the first 10 lines precede the
+trailer unchanged. Call `read` on the same file with no line params and assert
+the text contains no `// truncated` and no `// sha256` line. Then call `read`
+with `tail: 10` on the same file and assert the text matches
+`/^\/\/ truncated: showing last 10 lines$/m` and carries no `Continue:` — that
+is the branch with no `continuation` to build one from.
+
+The `.*` in the first regex is deliberate: it spans the hint, which is a fixed
+sentence the test has no reason to re-assert.
+
+**Verify**: `node scripts/tasks.mjs test` → `ℹ pass 273`, `ℹ fail 0`.
+
+### 4. `list`: `nextCursor` and overflow trailer in the text
+
+In [`list.ts:384-393`](../../../src/tools/list.ts#L384-L393) append to
+`markdown` before returning:
+
+- when `structured.nextCursor` is set: `\n\nnextCursor: <cursor>` — the model
+  passes it back verbatim as `cursor`;
+- when `structured.resourceUri` is set (hard-cap overflow, first page only):
+  `\n\ntruncated: <entryCount> of <totalEntries> entries shown; full tree at <resourceUri>`.
+
+Add `TC-FUNC-075: list text carries nextCursor` next to `TC-FUNC-063`: create
+4 files, `list` with `maxEntries: 2`, extract the cursor from the text with
+`/^nextCursor: (\S+)$/m`, assert it equals `result._meta.nextCursor`, call
+again with that cursor and assert the second page's text has no `nextCursor:`
+line.
+
+**Verify**: `node scripts/tasks.mjs test` → `ℹ pass 274`, `ℹ fail 0`.
+
+### 5. Instructions and changelog
+
+[`instructions.ts:72-73`](../../../src/instructions.ts#L72-L73): reword to
+`ephemeral_results: When a result carries a resource_link or a resourceUri
+(in structuredContent or _meta), call resources/read immediately — ...` and
+`pagination: nextCursor appears in the text (list) or _meta (find_files,
+search_text) and is backed by a snapshot on the same ~60s clock. ...`. Keep the
+rest of each line verbatim.
+
+[`CHANGELOG.md`](../../../CHANGELOG.md): add an `## [Unreleased]` section above
+`## [2.0.0] - 2026-08-27` with a `### Changed` entry: tools that return a text
+result (`read`, `list`, `diff`, `patch`, `edit`, `delete`, `move`,
+`replace_text`, `search_text`, `find_files`) now ship their metadata under
+`_meta` instead of `structuredContent`, so Claude Code renders the text; `read`
+appends a `// truncated:` / `// sha256:` trailer and `list` a `nextCursor:`
+line; no tool publishes an `outputSchema` any more; `stat`, `create` and
+`list_roots` drop their one-line summary and return JSON text, keeping
+`structuredContent`. Note the client-visible field move as a breaking change
+for programmatic consumers.
+
+**Verify**: `node scripts/tasks.mjs` → exit 0 (format check covers the
+changelog table alignment).
+
+### 6. End-to-end check in Claude Code
+
+`npm run build`, then from a shell:
+
+```bash
+printf '{"mcpServers":{"fsprobe":{"type":"stdio","command":"node","args":["C:/filesystem-mcp/dist/index.js","C:/filesystem-mcp"]}}}' > /tmp/fsprobe.json
+claude -p --mcp-config /tmp/fsprobe.json --strict-mcp-config --allowedTools "mcp__fsprobe__read,mcp__fsprobe__list" --output-format stream-json --verbose --model haiku "Call mcp__fsprobe__read with paths [\"C:/filesystem-mcp/AGENTS.md\"], then mcp__fsprobe__list with path C:/filesystem-mcp/src maxDepth 1. Reply done." < /dev/null | grep -o '"tool_result".\{0,120\}'
+```
+
+**Verify**: the `read` tool_result text begins `# filesystem-mcp` (file
+content, not `{"results":`), and the `list` tool_result text begins
+`src\n├──` (tree, not `{"path":`).
+
+## Done
+
+- [ ] `node scripts/tasks.mjs` exits 0
+- [ ] `node scripts/tasks.mjs test` reports `pass 274`, `fail 0`, including
+      `TC-FUNC-073`, `TC-FUNC-074`, `TC-FUNC-075`
+- [ ] Step 6 shows file text and tree in the Claude Code tool results
+- [ ] `git status` shows no modified files outside the in-scope list (plus
+      this plan directory)
+
+## STOP
+
+- The code at a [Current state](#current-state) location does not match its
+  excerpt.
+- A step's verification fails twice after one fix attempt.
+- The fix appears to require an out-of-scope file — in particular, if the
+  server SDK strips or rejects `_meta` on a `CallToolResult` (it did not in the
+  2026-09-05 probe against `@modelcontextprotocol/server` in `node_modules`).
+- Step 6 still shows JSON for `read` or `list`: the `_meta` assumption is
+  wrong for the installed Claude Code version; report the version from
+  `claude --version`.
+- `TOOL-SURFACE-002` (tools/list budget) fails after step 1 — it should only
+  get cheaper; a failure means something else changed the surface.
+
+## Notes
+
+- Reviewer focus: the trailer must never be mistaken for file bytes. The blank
+  line plus `//` prefix is the only guard; do not drop either.
+- Deliberately not done: an `FS_*` switch to keep `structuredContent` for
+  clients that prefer it. `_meta` carries the same object, so nothing is lost
+  for a programmatic consumer beyond the field name.
+- The `resource_link` blocks (`[Resource link: NAME] URI`, ~80 chars per file
+  in Claude Code) stay: they are the only carrier of the file URI now that
+  `resourceUri` is off the model-visible surface, and subscriptions key on it.
+- Rollback: `git revert` the landing commit; no data or schema migration.

--- a/docs/plan/2026-09-05-text-first-results/text-first-results.run.md
+++ b/docs/plan/2026-09-05-text-first-results/text-first-results.run.md
@@ -1,0 +1,120 @@
+# Run: Text-shaped tool results reach the model as text in Claude Code
+
+Executing [`text-first-results.plan.md`](text-first-results.plan.md), started
+2026-09-05 at `a7aa52d0`.
+
+- **Orient** 2026-09-05 — done. Drift check empty; `HEAD` at `a7aa52d0`; every
+  Current state excerpt matched its file.
+- **1** 2026-09-05 — **STOP**: the Current state inventory of text-supplying
+  tools is wrong, and step 1's Verify failed. `node scripts/tasks.mjs --quick`
+  → exit 0, but `node scripts/tasks.mjs test` → `tests 271 / pass 237 /
+  fail 34`, across tools the plan says are unaffected.
+
+## STOP at step 1
+
+**Condition**: two of the plan's own, together.
+
+1. "The code at a [Current state](text-first-results.plan.md#current-state)
+   location does not match its excerpt."
+2. Step 1's Verify: "failures only in the assertions listed under Current state
+   ... and in `TOOL-SURFACE-001`; **nothing else**."
+
+**Evidence**. The plan's `define.ts:95-99` bullet names the text-supplying
+tools as eight: "`delete-file`, `diff`, `edit`, `list`, `move`, `patch`,
+`read`, `stat`". The repo has **thirteen**. The five the plan missed:
+
+| Tool                       | Supplies `text` at                                             |
+| :------------------------- | :------------------------------------------------------------- |
+| `list_roots`               | [`roots.ts:34`](../../../src/tools/roots.ts#L34)                |
+| `create`                   | [`create.ts:165,168`](../../../src/tools/create.ts#L165)        |
+| `replace_text`             | [`replace-in-files.ts:691,693`](../../../src/tools/replace-in-files.ts#L691) |
+| `search_text`              | [`search-content.ts:467`](../../../src/tools/search-content.ts#L467) |
+| `find_files`               | [`search-files.ts:248`](../../../src/tools/search-files.ts#L248) |
+
+All five build the key as `const text = ...` and return `{ structured, text }`,
+which is why a grep for a `text:` property missed them.
+
+**Three consequences, each fatal to a different part of the plan.**
+
+1. `replace_text` keeps `publishOutputSchema: true`
+   ([`replace-in-files.ts:664`](../../../src/tools/replace-in-files.ts#L664))
+   because Scope declares it "supplies no `text`; keeps `outputSchema` and
+   `structuredContent`, unchanged". It does supply `text`, so it now publishes
+   an `outputSchema` and returns no `structuredContent` — the precise failure
+   the plan's own Current state warns about. `TC-FUNC-013r` fails with
+   `result.isError === true`
+   ([`tools.test.ts:1133`](../../../__tests__/tools.test.ts#L1133)).
+2. Step 5's instructions rewording says `nextCursor` "appears in the text
+   (list) or `structuredContent` (`find_files`, `search_text`)". Both of those
+   supply text, so both now ship `nextCursor` under `_meta`. The replacement
+   line would ship a false statement to every client.
+3. Step 2's `TC-FUNC-073` is built on the same false premise — "call
+   `find_files` ... assert the find_files result has `structuredContent`
+   defined". It cannot pass as written.
+
+**The 34 failures** are the listed assertions plus every test touching those
+five tools: `SMOKE-004`, `TC-FUNC-052` (`list_roots`); `TC-FUNC-014`,
+`find_files pages are stable` (`find_files`); `TC-FUNC-072`, `search_text pages
+are stable` (`search_text`); `TC-FUNC-013r` (`replace_text`); `TC-FUNC-064`
+through `TC-FUNC-071` (choice round-trips through `create`/`move`/`delete`);
+`INSP-CFG-002`, `INSP-STDIO-004`, `INSP-STDIO-009`, `STDIO-012`, `HTTP-004`.
+
+**Working tree**: step 1's code edits are applied and left in place —
+`define.ts` (the `_meta` rule, correct as written), `publishOutputSchema`
+removed from `read.ts`/`edit.ts`/`delete-file.ts`, and `stat.ts`'s text summary
+plus its `formatBytes` import removed. The rule itself is not what broke; its
+blast radius was mis-scoped. `git checkout -- src/` reverts all of it.
+
+**Hands to**: [write-plan](text-first-results.plan.md) — re-inventory the
+text-supplying tools from a grep that catches `const text = ...`, then rework
+Scope (`replace_text` moves in and loses `publishOutputSchema`, or keeps both
+by keeping `structuredContent`), the step 5 instructions wording, and
+`TC-FUNC-073`'s data-tool half. `list_roots` and `create` need a decision the
+plan never faced: their text is a summary, not a document, so they may belong
+with `stat` as data tools instead.
+
+## Resume 2026-09-05, after the plan was corrected
+
+Decisions from the user: `replace_text` moves in scope and drops its
+`outputSchema`; `list_roots` and `create` become data tools. Plan updated
+accordingly, then re-run from step 1.
+
+- **1** 2026-09-05 — done. `--quick` → exit 0; `test` → `pass 242 / fail 29`,
+  all 29 in the listed set, and every "must still pass" row green
+  (`SMOKE-004`, `TC-FUNC-052`, `INSP-CFG-002`, `INSP-STDIO-004`,
+  `TC-FUNC-015s`, `TC-FUNC-013r`).
+- **2** 2026-09-05 — done. `node scripts/tasks.mjs test` → `pass 272`, `fail 0`.
+- **3** 2026-09-05 — done. `node scripts/tasks.mjs test` → `pass 273`, `fail 0`.
+- **4** 2026-09-05 — done. `node scripts/tasks.mjs test` → `pass 274`, `fail 0`.
+- **5** 2026-09-05 — done. `node scripts/tasks.mjs` → exit 0, `pass 274`.
+- **6** 2026-09-05 — done. Headless `claude -p` probe: the `read` tool_result
+  text begins `# filesystem-mcp` and the `list` tool_result text begins
+  `src\n├──`. Both render as text, neither as JSON.
+
+## Done
+
+- [x] `node scripts/tasks.mjs` exits 0.
+- [x] `node scripts/tasks.mjs test` → `tests 274 / pass 274 / fail 0`, with
+      `TC-FUNC-073`, `TC-FUNC-074` and `TC-FUNC-075` all passing.
+- [x] Step 6 shows file text and tree in the Claude Code tool results.
+- [ ] **Deviation.** `git status` lists two files outside the plan's Scope:
+      [`src/core/fmt.ts`](../../../src/core/fmt.ts) and
+      [`src/core/util.ts`](../../../src/core/util.ts). Dropping `stat`'s and
+      `create`'s text summaries left `formatBytes` with no callers, and `knip`
+      fails the static gate on an unused export. `formatBytes` was deleted,
+      which orphaned `GIB` (deleted) and un-exported `KIB` (still used inside
+      `util.ts`). Forced by the plan's own gate, not a scope choice — but the
+      plan should have named it.
+
+## Notes review
+
+- **Trailer must never read as file bytes.** Held. `readTrailer`
+  ([`read.ts:341-362`](../../../src/tools/read.ts#L341)) emits every line `//`
+  prefixed and separates it from the content with exactly one blank line,
+  picking `\n` or `\n\n` by whether the content already ends in a newline.
+  `TC-FUNC-074` asserts the file's own lines precede the trailer unaltered.
+- **No `FS_*` switch to keep `structuredContent`.** Held; nothing was added.
+- **`resource_link` blocks stay.** Held;
+  [`file-uri.ts`](../../../src/core/file-uri.ts) untouched, and `git status`
+  confirms it.
+- **Rollback** is still a single `git revert` of the landing commit.

--- a/src/core/fmt.ts
+++ b/src/core/fmt.ts
@@ -1,8 +1,6 @@
 import { basename } from 'node:path';
 import { stripVTControlCharacters, styleText } from 'node:util';
 
-import { GIB, KIB, MIB } from './util.js';
-
 export interface ProgressCtx {
   label: string;
   subject?: string;
@@ -55,22 +53,6 @@ function buildBody(ctx: ProgressCtx, phase: Phase): string {
 export function plainMessage(phase: Phase, ctx: ProgressCtx): string {
   const body = buildBody(ctx, phase);
   return body ? `${ctx.label}: ${body}` : `${ctx.label}:`;
-}
-
-export function formatBytes(bytes: number): string {
-  if (!Number.isFinite(bytes) || bytes < 0) {
-    return '0 B';
-  }
-  if (bytes < KIB) {
-    return `${bytes} B`;
-  }
-  if (bytes < MIB) {
-    return `${(bytes / KIB).toFixed(1)} KB`;
-  }
-  if (bytes < GIB) {
-    return `${(bytes / MIB).toFixed(1)} MB`;
-  }
-  return `${(bytes / GIB).toFixed(1)} GB`;
 }
 
 export function formatCount(count: number, singular: string, plural = `${singular}s`): string {

--- a/src/core/schema.ts
+++ b/src/core/schema.ts
@@ -144,7 +144,10 @@ export const FileInfoSchema = z.strictObject({
   name: z.string(),
   path: z.string(),
   type: FileType,
-  size: NonNegInt,
+  // A directory's own inode size says nothing about what is inside it — 0 on
+  // Windows, 4096 on ext4 — so say so rather than letting a caller read it as
+  // "empty". This caveat used to live in stat's text summary, which is gone.
+  size: NonNegInt.describe('Bytes; meaningless for a directory — use list for its contents'),
   tokenEstimate: NonNegInt.optional().describe('Rough token estimate; use to pre-screen read cost'),
   created: IsoDateTime,
   modified: IsoDateTime,

--- a/src/core/util.ts
+++ b/src/core/util.ts
@@ -3,9 +3,8 @@ import { availableParallelism } from 'node:os';
 import { cli } from './config.js';
 import { Logger } from './observability.js';
 
-export const KIB = 1024;
+const KIB = 1024;
 export const MIB = 1024 * KIB;
-export const GIB = 1024 * MIB;
 
 const loggedWarns = new Set<string>();
 

--- a/src/instructions.ts
+++ b/src/instructions.ts
@@ -69,8 +69,8 @@ export function buildSectionsRecord(readOnly: boolean): Record<string, string> {
       'legacy_roots: Legacy clients may additionally seed roots through the deprecated roots/list flow.',
       'sensitive_paths: Sensitive file paths (.env, *.pem, *id_rsa*) are denied by default.',
       `enforced_limits: max file size ${maxFileMb} MB, file search cap ${MAX_SEARCH_RESULTS} results, content search cap ${DEFAULT_SEARCH_CONTENT_RESULTS} matches.`,
-      'ephemeral_results: When a tool returns resourceUri, call resources/read immediately — cached results are ephemeral and expire after ~60 seconds, eviction, or restart.',
-      'pagination: nextCursor is backed by a snapshot on the same ~60s clock. Page through promptly; if a cursor is rejected, start again without one. resourceUri appears on the first page only.',
+      'ephemeral_results: When a result carries a resource_link or a resourceUri (in structuredContent or _meta), call resources/read immediately — cached results are ephemeral and expire after ~60 seconds, eviction, or restart.',
+      'pagination: nextCursor appears in the text (list) or _meta (find_files, search_text) and is backed by a snapshot on the same ~60s clock. Page through promptly; if a cursor is rejected, start again without one. resourceUri appears on the first page only.',
       '```',
     ].join('\n'),
     error_recovery: [

--- a/src/tools/create.ts
+++ b/src/tools/create.ts
@@ -6,7 +6,6 @@ import * as z from 'zod/v4';
 
 import { ErrorCode } from '../core/errors.js';
 import { buildFileResourceLink, buildFileResourceUri } from '../core/file-uri.js';
-import { formatBytes, joinRoster } from '../core/fmt.js';
 import { detectMimeFromContent } from '../core/mime.js';
 import { countLines } from '../core/read.js';
 import {
@@ -62,26 +61,6 @@ const CreateOutputSchema = z.strictObject({
 });
 
 type CreateFileResult = z.infer<typeof CreateFileResultSchema>;
-
-function buildSummary(results: readonly CreateFileResult[], failCount: number): string {
-  if (results.length === 1 && failCount === 0) {
-    const result = results[0];
-    if (result) {
-      return [
-        `create: ${basename(result.path)}`,
-        formatBytes(result.size),
-        `${String(result.lineCount)} lines`,
-      ].join(' \u00b7 ');
-    }
-  }
-  // Name what was written. "create: 3 files" made the caller open
-  // structuredContent to learn which three \u2014 every other write tool answers
-  // with its roster.
-  const names = joinRoster(results.map((r) => basename(r.path)));
-  const parts = [`create: ${names || 'nothing'}`];
-  if (failCount > 0) parts.push(`${String(failCount)} failed`);
-  return parts.join(' \u00b7 ');
-}
 
 export const CREATE = defineTool({
   name: 'create',
@@ -159,13 +138,15 @@ export const CREATE = defineTool({
       files: results,
       ...(failures.length > 0 ? { failures } : {}),
     };
-    const summary = buildSummary(results, failures.length);
-
+    // No `text` on purpose. The one-line roster this used to build named the
+    // paths and dropped every per-file size, line count and error the caller
+    // asked `create` for. Supplying no text makes this a data tool, so
+    // `define.ts` renders the JSON and keeps it in `structuredContent`.
     if (links.length > 0) {
-      return { structured, text: summary, resources: links };
+      return { structured, resources: links };
     }
 
-    return { structured, text: summary };
+    return { structured };
   },
   progress: (args) => ({
     label: 'Create',

--- a/src/tools/define.ts
+++ b/src/tools/define.ts
@@ -248,17 +248,28 @@ function isTotalBatchFailure(structured: unknown): boolean {
 }
 
 /**
- * The spec asks a structured result to *also* carry the JSON as a text block,
- * for clients that read only `content`. Where a tool supplies its own `text`
- * (list's ASCII tree, read's file) that serves such a client better, so it
- * wins; tools with no `text` still fall back to the JSON.
+ * Claude Code — and any client that treats `structuredContent` as the canonical
+ * model view — discards the `text` blocks when `structuredContent` is present,
+ * showing the model `JSON.stringify(structuredContent)` instead. A tool that
+ * authored a text result (list's ASCII tree, read's file) meant that text for
+ * the model, so it ships its metadata under `_meta`, which no client renders in
+ * place of the content. Tools with no `text` keep `structuredContent`: the JSON
+ * *is* their model-facing view.
  */
 function buildSuccessResponse<O>(result: RunResult<O>): CallToolResult {
+  const hasText = result.text !== undefined;
   const text = result.text ?? JSON.stringify(result.structured);
   const content: ContentBlock[] = [{ type: 'text' as const, text }, ...(result.resources ?? [])];
   return {
     content,
-    structuredContent: result.structured,
+    ...(hasText
+      ? // Safe because every `ToolDef.output` is a Zod object schema, so
+        // `structured` is always a plain object. Constraining `O` to prove it
+        // is not worth the cost: the bound has to thread through five generic
+        // sites and still loses to `exactOptionalPropertyTypes` variance on
+        // `RunResult`'s optional fields.
+        { _meta: result.structured as Record<string, unknown> }
+      : { structuredContent: result.structured }),
     ...(isTotalBatchFailure(result.structured) ? { isError: true } : {}),
   };
 }

--- a/src/tools/delete-file.ts
+++ b/src/tools/delete-file.ts
@@ -418,9 +418,6 @@ export const DELETE_FILE = defineTool({
     'Workspace root directories cannot be deleted.',
   input: DeleteInputSchema,
   output: DeleteOutputSchema,
-  // results[].value XOR results[].error, and `deleted: false` means the user
-  // chose Skip rather than a failure — not inferable from the description.
-  publishOutputSchema: true,
   annotations: {
     readOnlyHint: false,
     idempotentHint: false,

--- a/src/tools/edit.ts
+++ b/src/tools/edit.ts
@@ -525,8 +525,6 @@ export const EDIT = defineTool({
     'For glob-based bulk regex replacement across many files, use replace_text instead.',
   input: EditFileInputSchema,
   output: EditFileOutputSchema,
-  // Same per-path union as read, plus diff, which is present only under dryRun.
-  publishOutputSchema: true,
   annotations: {
     readOnlyHint: false,
     idempotentHint: false,

--- a/src/tools/list.ts
+++ b/src/tools/list.ts
@@ -384,9 +384,21 @@ export const LIST = defineTool({
   accessPaths: (args) => (args.path ? [args.path] : []),
   run: async (args, ctx) => {
     const { structured, markdown, link } = await handleList(args, ctx);
+    // The tree is what the model reads; nextCursor and the overflow notice used
+    // to reach it only through the structured half, which now ships as _meta.
+    // Both ride the text so paging needs no second lookup.
+    const trailer: string[] = [];
+    if (structured.nextCursor !== undefined) {
+      trailer.push(`nextCursor: ${structured.nextCursor}`);
+    }
+    if (structured.resourceUri !== undefined) {
+      trailer.push(
+        `truncated: ${String(structured.entryCount)} of ${String(structured.totalEntries)} entries shown; full tree at ${structured.resourceUri}`,
+      );
+    }
     return {
       structured,
-      text: markdown,
+      text: trailer.length > 0 ? `${markdown}\n\n${trailer.join('\n')}` : markdown,
       ...(link ? { resources: [link] } : {}),
     };
   },

--- a/src/tools/read.ts
+++ b/src/tools/read.ts
@@ -339,6 +339,28 @@ function buildPerPathReadValue(
   };
 }
 
+/**
+ * The two facts the model cannot act on without: that lines were dropped, and
+ * the exact args to get the next chunk. Both used to live only in the structured
+ * half, which no longer reaches the model. Each line is `//` prefixed and set
+ * off by a blank line so it cannot be read as file bytes — do not drop either
+ * guard.
+ */
+function readTrailer(v: PerPathReadValue): string[] {
+  const lines: string[] = [];
+  if (v.continuation) {
+    lines.push(
+      `// truncated: ${v.continuation.hint} Continue: read ${JSON.stringify(v.continuation.args)}`,
+    );
+  } else if (v.hasMoreLines && v.linesRead !== undefined) {
+    // A tail read gets no continuation — there are no args that read *backwards*
+    // — so say what was shown rather than leaving the truncation silent.
+    lines.push(`// truncated: showing last ${String(v.linesRead)} lines`);
+  }
+  if (v.contentHash !== undefined) lines.push(`// sha256: ${v.contentHash}`);
+  return lines;
+}
+
 async function readOnePath(
   filePath: string,
   args: ReadFileInput,
@@ -392,9 +414,6 @@ export const READ_FILE = defineTool({
     'head, tail, and startLine/endLine are mutually exclusive — use exactly one.',
   input: ReadFileInputSchema,
   output: ReadFileOutputSchema,
-  // results[].value XOR results[].error, and value has no required field at all —
-  // not inferable from the description.
-  publishOutputSchema: true,
   annotations: {
     readOnlyHint: true,
     idempotentHint: true,
@@ -513,15 +532,23 @@ export const READ_FILE = defineTool({
     }
 
     const [firstOrdered] = ordered;
+    const body = (v: PerPathReadValue): string => {
+      const content = v.content ?? 'read failed';
+      const trailer = readTrailer(v);
+      if (trailer.length === 0) return content;
+      // Exactly one blank line between the bytes and the trailer, whether or not
+      // the file ended in a newline.
+      return `${content}${content.endsWith('\n') ? '\n' : '\n\n'}${trailer.join('\n')}`;
+    };
     const text =
       ordered.length === 1 && firstOrdered !== undefined
         ? 'error' in firstOrdered
           ? firstOrdered.error.message
-          : (firstOrdered.value.content ?? 'read failed')
+          : body(firstOrdered.value)
         : ordered
             .map((r) => {
               const header = `// ${r.path}`;
-              if ('value' in r) return `${header}\n${r.value.content}`;
+              if ('value' in r) return `${header}\n${body(r.value)}`;
               return `${header}\n// Error: ${r.error.message}`;
             })
             .join('\n\n');

--- a/src/tools/replace-in-files.ts
+++ b/src/tools/replace-in-files.ts
@@ -659,9 +659,6 @@ export const SEARCH_AND_REPLACE = defineTool({
     'Literal matching by default; set isRegex=true to enable RE2 regex with capture groups ($1, $2).',
   input: SearchAndReplaceInputSchema,
   output: SearchAndReplaceOutputSchema,
-  // results[].value XOR results[].error, and `summary` counts files while
-  // `totalMatches` counts replacements — not inferable from the description.
-  publishOutputSchema: true,
   annotations: {
     readOnlyHint: false,
     idempotentHint: false,

--- a/src/tools/roots.ts
+++ b/src/tools/roots.ts
@@ -24,12 +24,11 @@ export const LIST_ALLOWED_DIRECTORIES = defineTool({
   },
   run: (_args, ctx) => {
     const dirs = ctx.fs.pathGuard.getAllowedDirectories();
-    const structured = { roots: [...dirs] };
-    const text =
-      dirs.length > 0
-        ? dirs.join('\n')
-        : 'No allowed directories. Please configure allowed directories using CLI arguments, the FS_ALLOWED_DIRS environment variable, or --allow-cwd.';
-    return Promise.resolve({ structured, text });
+    // No `text` on purpose. A newline-joined path list and the JSON say the
+    // same thing, and the JSON is the shape every caller of this tool parses.
+    // Supplying no text makes this a data tool, so `define.ts` renders the JSON
+    // and keeps it in `structuredContent`.
+    return Promise.resolve({ structured: { roots: [...dirs] } });
   },
 
   defaultErrorCode: ErrorCode.UNKNOWN,

--- a/src/tools/stat.ts
+++ b/src/tools/stat.ts
@@ -5,7 +5,6 @@ import { parse } from 'node:path';
 import * as z from 'zod/v4';
 
 import { ErrorCode, rethrowIfAborted } from '../core/errors.js';
-import { formatBytes } from '../core/fmt.js';
 import type { FileInfo, GuardedFileSystem, Stats } from '../core/fs.js';
 import { getFileType, isHidden } from '../core/fs.js';
 import { detectMimeType } from '../core/mime.js';
@@ -245,21 +244,10 @@ export const GET_FILE_INFO = defineTool({
       resources.push(link);
     }
 
-    const text = perPathPayload
-      .map((r) => {
-        if (r.value) {
-          const { name, type, size } = r.value;
-          // A directory's own inode size says nothing about what is inside it
-          // (0 on Windows, 4096 on ext4), and "directory, 0 B" reads as empty.
-          // Use `list` for contents; report the byte size only where it means
-          // something.
-          if (type === 'directory') return `${name}: directory`;
-          return `${name}: ${type}, ${formatBytes(size)}`;
-        }
-        return `${r.path}: ${r.error?.message ?? 'error'}`;
-      })
-      .join('\n');
-
+    // No `text` on purpose. The one-liner this used to build (`AGENTS.md: file,
+    // 751 B`) dropped tokenEstimate, modified, mimeType and isHidden — the very
+    // fields a caller asks `stat` for. Supplying no text makes this a data tool,
+    // so `define.ts` renders the JSON and keeps it in `structuredContent`.
     return {
       structured: {
         results: perPathPayload,
@@ -268,7 +256,6 @@ export const GET_FILE_INFO = defineTool({
         dirCount,
         ...(resourceUri ? { resourceUri } : {}),
       },
-      text,
       ...(resources.length > 0 ? { resources } : {}),
     };
   },


### PR DESCRIPTION
## Why

Claude Code (verified on 2.1.261) drops every `text` content block from an MCP tool result whenever `structuredContent` is present, and shows the model `JSON.stringify(structuredContent)` instead.

Ten tools here author a model-facing `text` — file bytes, an ASCII tree, a unified diff — alongside a metadata-only structured half. So in Claude Code the model never saw the file `read` returned, nor the tree from `list`, and fell back to one `resources/read` round trip per file. Measured in one session: 3 dead `read` calls, 14 fallback resource reads, `list` at 3.9x the size of its own tree.

## What changed

A tool that supplies `text` now ships its structured half under `_meta`, which no client renders in place of the content. The two facts the model needs from that metadata ride the text instead:

- `read` appends `// truncated: <hint> Continue: read {"path":…,"startLine":…,"endLine":…}`, plus `// sha256: …` under `includeHash`. A `tail` read has no continuation args, so it reports `// truncated: showing last N lines`.
- `list` appends `nextCursor: <cursor>`, and a `truncated:` notice on hard-cap overflow.

Both are `//` prefixed and set off by exactly one blank line so neither can be read as file bytes.

`stat`, `create` and `list_roots` go the other way. Their `text` was a lossy one-line summary of a result whose value *is* the metadata, so they drop it and keep `structuredContent` — for those three the JSON is the model-facing view.

No tool publishes an `outputSchema` any more: publishing one obliges the result to carry `structuredContent`, and every publisher has stopped.

## Breaking

Programmatic consumers of `read`, `list`, `diff`, `patch`, `edit`, `delete`, `move`, `replace_text`, `search_text` and `find_files` must read `_meta` where they read `structuredContent`. Same object, different field.

## Verification

- `node scripts/tasks.mjs` → exit 0; `tests 274 / pass 274 / fail 0` (271 before, +3 new).
- New: `TC-FUNC-073` (text tools ship `_meta`, data tools ship `structuredContent`), `TC-FUNC-074` (read trailer: continuation, hash, tail, and none on a full read), `TC-FUNC-075` (list text carries `nextCursor`, and the last page does not).
- End-to-end headless `claude -p` probe against the built `dist/`: the `read` tool_result text begins `# filesystem-mcp` and the `list` tool_result text begins ``src\n├──`` — file content and tree, not `{"results":` and `{"path":`.

## Notes for review

- Dropping `stat`'s and `create`'s summaries left `formatBytes` with no callers, which `knip` fails the build on. It and the orphaned `GIB` are deleted, `KIB` is un-exported, and the directory-size caveat `formatBytes` carried moved to a `.describe()` on the schema field.
- `src/core/fmt.ts` and `src/core/util.ts` were outside the plan's scope; the static gate forced them. Recorded as a deviation in the run log.
- Two known follow-ups, both deliberate: `list_roots` no longer returns its empty-roots configuration guidance in `content` (text-only clients lose it; Claude Code showed the JSON before and after), and `publishOutputSchema` now has zero users.
- The plan, its adversarial review, and the run log are in `docs/plan/2026-09-05-text-first-results/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01W259NZqRWRcuvpHJYrkNsS
