### PR TITLE
fix: return configuration guidance when list_roots has none

### DIFF
--- a/__tests__/resources.test.ts
+++ b/__tests__/resources.test.ts
@@ -6,18 +6,14 @@ import { writeFile } from 'node:fs/promises';
 import { join } from 'node:path';
 import { after, before, describe, it } from 'node:test';
 
+import { NO_POSITIONAL_ROOTS_GUIDANCE } from '../src/core/config.js';
 import { ErrorCode, isFsError } from '../src/core/errors.js';
 import { buildFileResourceUri, encodeFileUriPath, extractPath } from '../src/core/file-uri.js';
 import { isSamePath } from '../src/core/path-utils.js';
 import { PathGuard } from '../src/core/path.js';
 import { ResourceStore } from '../src/core/store.js';
 import { createWatcherRegistry } from '../src/core/watcher-registry.js';
-import {
-  buildSectionsRecord,
-  INSTRUCTIONS_URI,
-  NO_POSITIONAL_ROOTS_GUIDANCE,
-  renderSections,
-} from '../src/instructions.js';
+import { buildSectionsRecord, INSTRUCTIONS_URI, renderSections } from '../src/instructions.js';
 import { getResourceContracts, registerResources } from '../src/resources.js';
 import { createServer } from '../src/server.js';
 import { MUTATING_TOOL_NAMES } from '../src/tools/index.js';

--- a/__tests__/tools.test.ts
+++ b/__tests__/tools.test.ts
@@ -495,8 +495,26 @@ describe('P0 Functional Tests - Tools (MCP Client)', () => {
   it('TC-FUNC-052: List roots via MCP tool call', async () => {
     const result = await harness.client.callTool({ name: 'list_roots' });
     assert.notStrictEqual(result.isError, true);
-    const structured = result.structuredContent as { roots?: string[] } | undefined;
+    const structured = result.structuredContent as { roots?: string[]; hint?: string } | undefined;
     assert.ok((structured?.roots?.length ?? 0) > 0, 'Should have at least one allowed directory');
+    assert.strictEqual(structured?.hint, undefined, 'a configured server pays for no hint');
+  });
+
+  it('TC-FUNC-052b: list_roots with no roots says how to configure them', async () => {
+    // An empty `roots` reports the problem; without this the caller learns
+    // nothing about the fix, and the elicitation route out is in no description.
+    const bare = await createTestClientPair([]);
+    try {
+      const result = await bare.client.callTool({ name: 'list_roots' });
+      assert.notStrictEqual(result.isError, true);
+      const structured = result.structuredContent as { roots?: string[]; hint?: string };
+      assert.deepStrictEqual(structured.roots, []);
+      assert.match(structured.hint ?? '', /FS_ALLOWED_DIRS/);
+      assert.match(structured.hint ?? '', /--allow-cwd/);
+      assert.match(structured.hint ?? '', /approve the requested grant/);
+    } finally {
+      await bare.close();
+    }
   });
 
   it('TC-FUNC-053: Copy with overwrite: true succeeds when destination exists', async () => {

--- a/src/core/config.ts
+++ b/src/core/config.ts
@@ -7,6 +7,15 @@
 // back to the operator's environment. This module deliberately has zero imports
 // so any core module can read it without a cycle.
 
+/**
+ * How an operator gives this server a root. Lives here rather than beside its
+ * readers because both ends of the repo need it — `index.ts` prints it at
+ * startup, `list_roots` returns it when it has nothing to list — and this
+ * module is the one place either can import without a cycle.
+ */
+export const NO_POSITIONAL_ROOTS_GUIDANCE =
+  'No positional directories specified. Configure roots with directory arguments, FS_ALLOWED_DIRS, or --allow-cwd. Modern clients with elicitation can also call a tool with a concrete path and approve the requested grant.';
+
 export interface CliOverrides {
   /** `--log-level` */
   logLevel?: string;

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,8 +8,8 @@ import process from 'node:process';
 import * as z from 'zod/v4';
 
 import { CliExitError, parseArgs, runPrintConfig } from './cli.js';
+import { NO_POSITIONAL_ROOTS_GUIDANCE } from './core/config.js';
 import { logRuntimeFailure } from './core/observability.js';
-import { NO_POSITIONAL_ROOTS_GUIDANCE } from './instructions.js';
 import { startHttpServer, startServer } from './transport.js';
 
 z.config(z.locales.en());

--- a/src/instructions.ts
+++ b/src/instructions.ts
@@ -32,8 +32,6 @@ function buildToolsOverview(readOnly: boolean): string {
 }
 
 export const INSTRUCTIONS_URI = 'internal://instructions';
-export const NO_POSITIONAL_ROOTS_GUIDANCE =
-  'No positional directories specified. Configure roots with directory arguments, FS_ALLOWED_DIRS, or --allow-cwd. Modern clients with elicitation can also call a tool with a concrete path and approve the requested grant.';
 
 /**
  * The one statement of what this server is and how to approach it. The server's

--- a/src/tools/roots.ts
+++ b/src/tools/roots.ts
@@ -1,5 +1,6 @@
 import * as z from 'zod/v4';
 
+import { NO_POSITIONAL_ROOTS_GUIDANCE } from '../core/config.js';
 import { ErrorCode } from '../core/errors.js';
 import { defineTool } from './define.js';
 
@@ -7,6 +8,10 @@ const RootsInputSchema = z.strictObject({});
 
 const RootsOutputSchema = z.strictObject({
   roots: z.array(z.string()).describe('Absolute paths of the allowed workspace root directories'),
+  hint: z
+    .string()
+    .optional()
+    .describe('How to configure roots; present only when there are none to list'),
 });
 
 export const LIST_ALLOWED_DIRECTORIES = defineTool({
@@ -28,7 +33,18 @@ export const LIST_ALLOWED_DIRECTORIES = defineTool({
     // same thing, and the JSON is the shape every caller of this tool parses.
     // Supplying no text makes this a data tool, so `define.ts` renders the JSON
     // and keeps it in `structuredContent`.
-    return Promise.resolve({ structured: { roots: [...dirs] } });
+    //
+    // `hint` rides the same JSON so the recovery reaches every client. An empty
+    // `roots` says the call failed to be useful but not what to do about it,
+    // and the elicitation route out — call a tool with a concrete path and
+    // approve the grant — appears in no tool description. It is conditional
+    // because a configured server pays nothing to be told how to configure.
+    return Promise.resolve({
+      structured: {
+        roots: [...dirs],
+        ...(dirs.length === 0 ? { hint: NO_POSITIONAL_ROOTS_GUIDANCE } : {}),
+      },
+    });
   },
 
   defaultErrorCode: ErrorCode.UNKNOWN,


### PR DESCRIPTION
Follow-up to #14, from its review.

## Why

Dropping `list_roots`' text summary in #14 took its empty-roots guidance with it. A misconfigured server now answers `{"roots":[]}` — the problem, with no route out.

The tool description does name the CLI flag and the env var, so that much survives. What it never carried is the recovery a modern client actually has: call a tool with a concrete path and approve the requested grant.

## What changed

`roots` gains an optional `hint`, populated only when there is nothing to list, reusing the `NO_POSITIONAL_ROOTS_GUIDANCE` string `index.ts` already prints at startup.

Two choices worth naming:

- **Conditional, not always-on.** A configured server should pay nothing to be told how to configure itself.
- **In the JSON, not the description.** A description is billed on every `tools/list`; this repo pins that budget in `TOOL-SURFACE-002`. `list_roots` publishes no `outputSchema`, so the new field costs zero wire bytes until it is actually used.

`NO_POSITIONAL_ROOTS_GUIDANCE` moves from `instructions.ts` to `core/config.ts` to reach both ends without an import cycle — `instructions.ts` imports `tools/index.js`, which imports every tool, so a tool importing back would close the loop. `core/config.ts` is the module already documented as importing nothing for exactly this reason.

## Verification

- `node scripts/tasks.mjs` → exit 0; `tests 275 / pass 275 / fail 0` (274 before, +1).
- New `TC-FUNC-052b`: boots a server with no roots, asserts the hint names `FS_ALLOWED_DIRS`, `--allow-cwd`, and the grant-approval route.
- `TC-FUNC-052` extended to assert a configured server returns no `hint`, so the conditional cannot silently become unconditional.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01W259NZqRWRcuvpHJYrkNsS
