### PR TITLE
refactor: drop the dead publishOutputSchema switch

### DIFF
--- a/src/tools/define.ts
+++ b/src/tools/define.ts
@@ -125,14 +125,6 @@ export interface ToolDef<I extends z.ZodType, O extends z.ZodType> {
    * caller-supplied filesystem paths.
    */
   readonly accessPaths?: (args: z.infer<I>) => readonly string[];
-  /**
-   * Publish `output` as the tool's wire `outputSchema`. Off by default: the
-   * spec makes the field optional and it costs more than every other part of
-   * a tool entry combined. Turn it on only where the shape is not inferable —
-   * a discriminated per-path union, or a field that appears under one flag and
-   * not another. The Zod object still validates every result either way.
-   */
-  readonly publishOutputSchema?: boolean;
   readonly run: (
     args: z.infer<I>,
     ctx: ToolCtx,
@@ -539,7 +531,6 @@ export function defineTool<I extends z.ZodType, O extends z.ZodType>(
   def: ToolDef<I, O>,
 ): DefinedTool {
   const inputJsonSchema = toDraft202012(def.input, 'input');
-  const outputJsonSchema = toDraft202012(def.output, 'output');
 
   // Nothing here depends on `deps`, so it is built once per tool definition
   // rather than once per `register` — the HTTP leg registers every tool afresh
@@ -561,17 +552,14 @@ export function defineTool<I extends z.ZodType, O extends z.ZodType>(
     title: def.title,
     description: def.description,
     inputSchema: fromJsonSchema<z.infer<I>>(inputJsonSchema, zodJsonSchemaValidator(def.input)),
-    // The validator is built either way — results are still checked against the
-    // Zod object — but the schema reaches the wire only where the shape is not
-    // inferable from the description plus the text content.
-    ...(def.publishOutputSchema
-      ? {
-          outputSchema: fromJsonSchema<z.infer<O>>(
-            outputJsonSchema,
-            zodJsonSchemaValidator(def.output),
-          ),
-        }
-      : {}),
+    // No `outputSchema`, ever. Publishing one obliges the result to carry
+    // `structuredContent` (clients enforce it), and every tool that authors its
+    // own text ships its metadata under `_meta` instead — see
+    // `buildSuccessResponse`. The two cannot both hold, and the text is what
+    // the model reads. `TOOL-SURFACE-001` pins this for the whole surface.
+    //
+    // `def.output` stays: it types `RunResult<z.infer<O>>`, which is what makes
+    // a tool returning the wrong shape a compile error.
     annotations: publishedAnnotations,
   };
 


### PR DESCRIPTION
Last item from the #14 review. Deletion only — 8 insertions, 20 deletions, all in one file.

## Why

`publishOutputSchema` had four users: `read`, `edit`, `delete` and `replace_text`. All four dropped it in #14, because publishing an `outputSchema` obliges the result to carry `structuredContent`, and every one of those tools now ships its metadata under `_meta` instead. The two cannot both hold.

A switch nothing can turn on still reads as a live decision point to the next person defining a tool.

## What changed

- Removed the `publishOutputSchema` field and its doc comment from `ToolDef`.
- Removed the conditional `outputSchema` spread in `defineTool`, and the now-orphaned `outputJsonSchema`.
- Replaced the comment with why there is no `outputSchema` at all, pointing at `buildSuccessResponse` and `TOOL-SURFACE-001`.

## One thing worth knowing

Removing the branch leaves `def.output` with **no runtime reader**. The old comment claimed "the Zod object still validates every result either way" — that route ran through the removed branch, so as of #14 it was already true for zero tools.

`def.output` stays regardless: it types `RunResult<z.infer<O>>`, which is what makes a tool returning the wrong shape a compile error. The new comment says that instead of the old claim. Restoring runtime result validation would be a separate change, and nothing in the current design needs it.

## Verification

`node scripts/tasks.mjs` → exit 0; `tests 275 / pass 275 / fail 0`. No test changed — `TOOL-SURFACE-001` already asserts every tool publishes no `outputSchema`, so the invariant left behind is tested, not just commented.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01W259NZqRWRcuvpHJYrkNsS
