### PR TITLE
refactor: cut dead error path, merge move/copy

### DIFF
--- a/__tests__/tools.test.ts
+++ b/__tests__/tools.test.ts
@@ -596,6 +596,34 @@ describe('P0 Functional Tests - Tools (MCP Client)', () => {
     }
   });
 
+  it('move and copy both refuse a destination inside the source directory', async () => {
+    // `planTransfer` runs ONE containment guard for both ops. Move used to
+    // build its own `source + sep` prefix test, which never matched a bare
+    // filesystem root; the shared `isPathInsideDirectory` does. Pin both ops so
+    // the stricter semantics stay deliberate — a directory moved or copied into
+    // its own subtree recurses into itself.
+    const srcDir = join(tmpDir, 'selfnest_src');
+    await mkdir(srcDir, { recursive: true });
+    await writeFile(join(srcDir, 'f.txt'), 'x');
+    const inside = join(srcDir, 'nested', 'target');
+
+    for (const copy of [false, true]) {
+      const label = `copy=${String(copy)}`;
+      const result = await harness.client.callTool({
+        name: 'move',
+        arguments: { moves: [{ source: srcDir, destination: inside }], copy },
+      });
+      assert.strictEqual(result.isError, true, `${label} must be refused`);
+      const { failures = [] } = result._meta as {
+        failures?: { error: { code: string; message: string } }[];
+      };
+      assert.strictEqual(failures.length, 1, `${label} reports one failure`);
+      assert.strictEqual(failures[0]?.error.code, 'INVALID_INPUT', label);
+      assert.match(failures[0]?.error.message ?? '', /own subdirectory/, label);
+      await assert.rejects(access(inside), `${label} created nothing`);
+    }
+  });
+
   it('TC-FUNC-058: list tool declares idempotentHint', () => {
     const listTool = ALL_TOOLS.find((t) => t.name === 'list');
     assert.ok(listTool, 'list tool should be defined');

--- a/src/core/errors.ts
+++ b/src/core/errors.ts
@@ -1,7 +1,5 @@
 import { ProtocolErrorCode } from '@modelcontextprotocol/server';
 
-import * as z from 'zod/v4';
-
 export const ErrorCode = {
   ACCESS_DENIED: 'ACCESS_DENIED',
   NOT_FOUND: 'NOT_FOUND',
@@ -14,7 +12,6 @@ export const ErrorCode = {
   INVALID_INPUT: 'INVALID_INPUT',
   PERMISSION_DENIED: 'PERMISSION_DENIED',
   SYMLINK_NOT_ALLOWED: 'SYMLINK_NOT_ALLOWED',
-  VALIDATION_FAILED: 'VALIDATION_FAILED',
   IO_ERROR: 'IO_ERROR',
   UNKNOWN: 'UNKNOWN',
 } as const;
@@ -32,23 +29,12 @@ export interface Problem {
   readonly code: ErrorCode;
   readonly message: string;
   readonly path?: string;
-  readonly issues?: readonly ProblemIssue[];
   readonly suggestion?: string;
-}
-
-interface ProblemIssue {
-  readonly path: readonly (string | number)[];
-  readonly code: string;
-  readonly message: string;
-  readonly expected?: string;
-  readonly received?: string;
-  readonly params?: Readonly<Record<string, unknown>>;
 }
 
 interface ProblemFactoryOptions {
   path?: string;
   suggestion?: string;
-  issues?: readonly ProblemIssue[];
 }
 
 function build(code: ErrorCode, message: string, opts: ProblemFactoryOptions = {}): Problem {
@@ -57,7 +43,6 @@ function build(code: ErrorCode, message: string, opts: ProblemFactoryOptions = {
     message,
     ...(opts.path !== undefined ? { path: opts.path } : {}),
     ...(opts.suggestion !== undefined ? { suggestion: opts.suggestion } : {}),
-    ...(opts.issues !== undefined ? { issues: opts.issues } : {}),
   };
 }
 
@@ -76,16 +61,14 @@ export const Problem = {
     const shouldOverride =
       problem.code === ErrorCode.UNKNOWN || problem.code === ErrorCode.IO_ERROR;
     const code = shouldOverride ? defaultCode : problem.code;
-    const baseSuggestion =
-      problem.suggestion ?? resolveSuggestion({ code: problem.code, issues: problem.issues ?? [] });
-    const suggestion = (shouldOverride ? DEFAULT_SUGGESTIONS[code] : undefined) ?? baseSuggestion;
+    const suggestion =
+      (shouldOverride ? DEFAULT_SUGGESTIONS[code] : undefined) ??
+      problem.suggestion ??
+      DEFAULT_SUGGESTIONS[problem.code];
     const resolvedPath = path ?? problem.path;
     return build(code, problem.message, {
       ...(resolvedPath !== undefined ? { path: resolvedPath } : {}),
       ...(suggestion !== undefined ? { suggestion } : {}),
-      ...(problem.issues !== undefined && problem.issues.length > 0
-        ? { issues: problem.issues }
-        : {}),
     });
   },
   toText(error: unknown, defaultCode: ErrorCode): { code: ErrorCode; text: string } {
@@ -118,14 +101,6 @@ const DEFAULT_SUGGESTIONS: Readonly<Partial<Record<ErrorCode, string>>> = {
   [ErrorCode.PERMISSION_DENIED]: 'Check OS file permissions.',
   [ErrorCode.SYMLINK_NOT_ALLOWED]: 'Symlink escapes allowed directories.',
 };
-
-function resolveSuggestion(p: Pick<Problem, 'code' | 'issues'>): string | undefined {
-  for (const issue of p.issues ?? []) {
-    const fromRule = issue.params?.['suggestion'];
-    if (typeof fromRule === 'string') return fromRule;
-  }
-  return DEFAULT_SUGGESTIONS[p.code];
-}
 
 export const ERRNO_MAP: Readonly<Record<string, ErrorCode>> = {
   ENOENT: ErrorCode.NOT_FOUND,
@@ -250,38 +225,6 @@ function buildProblemFromSignal(signal: ClassificationSignal, error: unknown): P
   }
 }
 
-function toProblemIssue(issue: z.core.$ZodIssue): ProblemIssue {
-  const base: ProblemIssue = {
-    path: issue.path as readonly (string | number)[],
-    code: issue.code,
-    message: issue.message,
-  };
-  const expected = (issue as { expected?: string }).expected;
-  const received = (issue as { received?: string }).received;
-  const rawParams = (issue as { params?: unknown }).params;
-  const params =
-    rawParams === undefined || rawParams === null
-      ? undefined
-      : typeof rawParams === 'object'
-        ? (rawParams as Record<string, unknown>)
-        : { value: rawParams };
-  return {
-    ...base,
-    ...(expected !== undefined ? { expected } : {}),
-    ...(received !== undefined ? { received } : {}),
-    ...(params !== undefined ? { params } : {}),
-  };
-}
-
-function zodErrorToProblem(err: z.ZodError): Problem {
-  const issues = err.issues.map(toProblemIssue);
-  const suggestion = resolveSuggestion({ code: ErrorCode.VALIDATION_FAILED, issues });
-  return build(ErrorCode.VALIDATION_FAILED, z.prettifyError(err), {
-    issues,
-    ...(suggestion !== undefined ? { suggestion } : {}),
-  });
-}
-
 export function isFsError(error: unknown): error is FsError {
   if (!(error instanceof Error) || error.name !== 'FsError') return false;
   if (!('problem' in error)) return false;
@@ -316,7 +259,12 @@ function classify(error: unknown): Problem {
     return Problem.unknown('Unknown error');
   }
   if (isFsError(error)) return error.problem;
-  if (error instanceof z.ZodError) return zodErrorToProblem(error);
+  // No `ZodError` branch, deliberately. Tool arguments are validated by
+  // `safeParse` inside the SDK's validator seam (tools/define.ts), which never
+  // throws — it hands back `z.prettifyError`'s string — and nothing in `src/`
+  // calls `.parse()`. A ZodError reaching here would fall through to
+  // `Problem.unknown` with Zod's raw JSON-dump `.message`, so if a `.parse()`
+  // is ever added, add the branch back with it rather than discovering this.
   if (!(error instanceof Error)) {
     return Problem.unknown(typeof error === 'string' ? error : '[non-Error thrown]');
   }

--- a/src/core/schema.ts
+++ b/src/core/schema.ts
@@ -220,12 +220,8 @@ export function validateReadRange(
     ctx.addIssue({
       code: 'custom',
       path: ['head'],
-      message: "Cannot use 'head' with 'startLine'/'endLine'",
-      params: {
-        rule: 'head_no_line_range',
-        conflictsWith: ['startLine', 'endLine'],
-        suggestion: "Use either 'head' alone or 'startLine'/'endLine' together.",
-      },
+      message:
+        "Cannot use 'head' with 'startLine'/'endLine'. Use either 'head' alone or 'startLine'/'endLine' together.",
       input: value,
     });
   }
@@ -233,12 +229,8 @@ export function validateReadRange(
     ctx.addIssue({
       code: 'custom',
       path: ['tail'],
-      message: "Cannot use 'tail' with 'head'/'startLine'/'endLine'",
-      params: {
-        rule: 'tail_exclusive',
-        conflictsWith: ['head', 'startLine', 'endLine'],
-        suggestion: "Use 'tail' alone or use 'startLine'/'endLine' without 'tail'.",
-      },
+      message:
+        "Cannot use 'tail' with 'head'/'startLine'/'endLine'. Use 'tail' alone, or 'startLine'/'endLine' without 'tail'.",
       input: value,
     });
   }
@@ -246,11 +238,7 @@ export function validateReadRange(
     ctx.addIssue({
       code: 'custom',
       path: ['endLine'],
-      message: "'endLine' requires 'startLine' to be set",
-      params: {
-        rule: 'endLine_requires_startLine',
-        suggestion: "Provide both 'startLine' and 'endLine' together.",
-      },
+      message: "'endLine' requires 'startLine' to be set. Provide both together.",
       input: value,
     });
   }
@@ -260,11 +248,6 @@ export function validateReadRange(
       code: 'custom',
       path: ['endLine'],
       message: "'endLine' must be >= 'startLine'",
-      params: {
-        rule: 'endLine_gte_startLine',
-        conflictsWith: ['startLine'],
-        suggestion: 'Set endLine to a value greater than or equal to startLine.',
-      },
       input: value,
     });
   }

--- a/src/tools/move.ts
+++ b/src/tools/move.ts
@@ -1,7 +1,7 @@
 import type { InputRequiredResult } from '@modelcontextprotocol/server';
 import { isInputRequiredResult } from '@modelcontextprotocol/server';
 
-import { basename, dirname, resolve, sep } from 'node:path';
+import { basename, dirname, resolve } from 'node:path';
 
 import * as z from 'zod/v4';
 
@@ -17,7 +17,7 @@ import { joinRoster, pathLabel } from '../core/fmt.js';
 import { destExists } from '../core/fs.js';
 import type { GuardedFileSystem } from '../core/fs.js';
 import { readAcceptedChoice } from '../core/input-required.js';
-import { IS_CASE_INSENSITIVE_FS, isPathInsideDirectory, isSamePath } from '../core/path-utils.js';
+import { isPathInsideDirectory, isSamePath } from '../core/path-utils.js';
 import { defaultFalseBoolean, PerFileErrorSchema, RequiredPath } from '../core/schema.js';
 import type { PairExecResult, PairPlanResult } from './batch.js';
 import { isTotalFailure, pairFailure, runOverPairs } from './batch.js';
@@ -64,93 +64,107 @@ const MoveOutputSchema = z.strictObject({
 
 type MoveItemResult = z.infer<typeof MoveItemResultSchema>;
 
-/** A move pre-checked up to the point a confirmation decision is needed. */
-interface MovePlan {
+type PairOp = 'move' | 'copy';
+
+const VERB: Readonly<Record<PairOp, string>> = { move: 'Move', copy: 'Copy' };
+
+/** A move or copy pre-checked up to the point a confirmation decision is needed. */
+interface TransferPlan {
   pair: { source: string; destination: string };
-  renamePath: string;
+  /**
+   * The path the mutation runs on: the link itself for a move, the resolved
+   * target for a copy. Every collision check uses the resolved source instead
+   * — see {@link validateTransferSource}.
+   */
+  opSource: string;
   validDest: string;
+  /**
+   * A rename that only changes the destination's case. Move must perform it —
+   * it is real work — so it is exempt from the destination-exists checks that
+   * would otherwise read the source itself as an existing destination. Never
+   * true for a copy, which treats a case-only target as a self-copy and skips.
+   */
   isCaseOnlyRename: boolean;
   /** Whether the destination existed when planned (drives the TOCTOU guard). */
   destExistedOriginally: boolean;
-  /** Destination exists and is not a self/case-only move → needs overwrite confirmation. */
+  /** Destination exists and is not a self/case-only target → needs overwrite confirmation. */
   pending: boolean;
 }
 
 /**
- * Phase 1 (no mutation): validate source and destination, reject self-moves and
- * moves into a subdirectory of the source, and stat the destination to decide
- * whether this move needs an overwrite confirmation. No `mkdir` happens here —
- * the old flow created the destination's parent before asking, which mutated
- * the filesystem before a confirmation; that now waits for phase 2 (R14).
+ * Phase 1 (no mutation): validate source and destination, reject self-targets
+ * and transfers into a subdirectory of the source, and stat the destination to
+ * decide whether this pair needs an overwrite confirmation. No `mkdir` happens
+ * here — the old flow created the destination's parent before asking, which
+ * mutated the filesystem before a confirmation; that now waits for phase 2 (R14).
+ *
+ * `overwrite` is copy-only — move has no confirmation bypass — so a move always
+ * passes false.
  */
-async function planMove(
-  move: { source: string; destination: string },
+async function planTransfer(
+  op: PairOp,
+  pair: { source: string; destination: string },
   fs: ToolCtx['fs'],
-): Promise<PairPlanResult<MovePlan>> {
-  let renamePath: string;
-  let realPath: string;
-  try {
-    ({ renamePath, realPath } = await validateMoveSource(move.source, fs));
-  } catch (error) {
-    return { status: 'fail', failure: pairFailure(move, error) };
-  }
-
+  overwrite: boolean,
+): Promise<PairPlanResult<TransferPlan>> {
+  let realSource: string;
+  let opSource: string;
   let validDest: string;
   try {
-    validDest = await fs.pathGuard.validatePathForWrite(move.destination);
+    ({ realSource, opSource } = await validateTransferSource(op, pair.source, fs));
+    validDest = await fs.pathGuard.validatePathForWrite(pair.destination);
   } catch (error) {
-    return { status: 'fail', failure: pairFailure(move, error) };
+    return { status: 'fail', failure: pairFailure(pair, error) };
   }
 
-  // Comparisons run on the resolved source; only the fs call below uses
-  // renamePath. validatePathForWrite resolves the destination through a
-  // symlink too, so both sides of every check must be resolved to match.
-  const resolvedSource = resolve(realPath);
+  // Comparisons run on the resolved source; only the fs call in phase 2 uses
+  // opSource. validatePathForWrite resolves the destination through a symlink
+  // too, so both sides of every check must be resolved to match.
+  const resolvedSource = resolve(realSource);
   const resolvedDest = resolve(validDest);
 
-  if (resolvedSource === resolvedDest) {
-    // Self-move — silently skip.
+  const isSelf = resolvedSource === resolvedDest;
+  const isCaseOnlyRename = !isSelf && isSamePath(resolvedSource, resolvedDest);
+
+  // A copy onto a case-only variant of its own source is the same file, so it
+  // is a no-op; the same rename is real work for move and proceeds.
+  if (isSelf || (isCaseOnlyRename && op === 'copy')) {
     return { status: 'noop' };
   }
 
-  const normalizedDest = IS_CASE_INSENSITIVE_FS ? resolvedDest.toLowerCase() : resolvedDest;
-  const normalizedSource = IS_CASE_INSENSITIVE_FS
-    ? (resolvedSource + sep).toLowerCase()
-    : resolvedSource + sep;
-
-  if (normalizedDest.startsWith(normalizedSource)) {
+  if (!isCaseOnlyRename && isPathInsideDirectory(resolvedSource, resolvedDest)) {
     return {
       status: 'fail',
       failure: pairFailure(
-        move,
+        pair,
         new FsError(
           ErrorCode.INVALID_INPUT,
-          'Cannot move a directory into its own subdirectory',
-          move.source,
+          `Cannot ${op} a directory into its own subdirectory`,
+          pair.source,
         ),
       ),
     };
   }
 
-  const isCaseOnlyRename = isSamePath(resolvedSource, resolvedDest);
-  const destExistedOriginally = !isCaseOnlyRename && (await destExists(fs, validDest, 'move'));
+  const destExistedOriginally = !isCaseOnlyRename && (await destExists(fs, validDest, op));
+  const pending = destExistedOriginally && !overwrite;
 
-  const pending = !isCaseOnlyRename && destExistedOriginally;
   return {
     status: 'plan',
-    plan: { pair: move, renamePath, validDest, isCaseOnlyRename, destExistedOriginally, pending },
+    plan: { pair, opSource, validDest, isCaseOnlyRename, destExistedOriginally, pending },
   };
 }
 
 /**
- * Phase 2 (mutation): confirm an overwrite if needed, create the destination's
- * parent, TOCTOU-check the destination, then rename (with cross-device fallback).
- * A declined/missing confirmation throws `CANCELLED`, collected as a per-move
- * failure by the caller. A destination that appeared between plan and rename
- * (created during the confirmation gap) also fails closed.
+ * Phase 2 (mutation): confirm an overwrite if needed, TOCTOU-check the
+ * destination, create its parent, then rename (with cross-device fallback) or
+ * copy. A declined/missing confirmation throws `CANCELLED`, collected as a
+ * per-pair failure by the caller. A destination that appeared between plan and
+ * mutation (created during the confirmation gap) also fails closed.
  */
-async function executeMove(
-  plan: MovePlan,
+async function executeTransfer(
+  op: PairOp,
+  plan: TransferPlan,
   ctx: Pick<ToolCtx, 'fs' | 'signal' | 'inputResponses' | 'log'>,
   pendingSorted: readonly string[],
 ): Promise<PairExecResult<MoveItemResult>> {
@@ -163,7 +177,7 @@ async function executeMove(
     if (choice !== 'overwrite') {
       throw new FsError(
         ErrorCode.CANCELLED,
-        `Move cancelled: overwrite of "${plan.pair.destination}" was declined or missing`,
+        `${VERB[op]} cancelled: overwrite of "${plan.pair.destination}" was declined or missing`,
         plan.pair.destination,
       );
     }
@@ -171,121 +185,32 @@ async function executeMove(
 
   // TOCTOU check before any mutation: a destination that did not exist when
   // planned but exists now was created during the confirmation gap.
-  if (!plan.isCaseOnlyRename) {
-    const existsNow = await destExists(ctx.fs, plan.validDest, 'move');
-    if (existsNow && !plan.destExistedOriginally) {
-      throw new FsError(
-        ErrorCode.CANCELLED,
-        `Move cancelled: destination "${plan.pair.destination}" was created during confirmation.`,
-        plan.pair.destination,
-      );
-    }
-  }
-
-  await ctx.fs.mkdir(dirname(plan.validDest), { recursive: true });
-
-  await performRenameWithFallback(plan.renamePath, plan.validDest, ctx.fs, plan.pair.source);
-  ctx.log?.('info', `move: ${plan.pair.source} -> ${plan.pair.destination}`, 'move');
-  return { value: { from: plan.renamePath, to: plan.validDest } };
-}
-
-/** A copy pre-checked up to the point a confirmation decision is needed. */
-interface CopyPlan {
-  pair: { source: string; destination: string };
-  realSource: string;
-  validDest: string;
-  destExistedOriginally: boolean;
-  pending: boolean;
-}
-
-async function planCopy(
-  copy: { source: string; destination: string },
-  fs: ToolCtx['fs'],
-  overwrite: boolean,
-): Promise<PairPlanResult<CopyPlan>> {
-  let realSource: string;
-  try {
-    realSource = await fs.pathGuard.validateExistingPath(copy.source);
-  } catch (error) {
-    return { status: 'fail', failure: pairFailure(copy, error) };
-  }
-
-  let validDest: string;
-  try {
-    validDest = await fs.pathGuard.validatePathForWrite(copy.destination);
-  } catch (error) {
-    return { status: 'fail', failure: pairFailure(copy, error) };
-  }
-
-  if (isSamePath(realSource, validDest)) {
-    // Self-copy — noop
-    return { status: 'noop' };
-  }
-
-  if (isPathInsideDirectory(realSource, validDest)) {
-    return {
-      status: 'fail',
-      failure: pairFailure(
-        copy,
-        new FsError(
-          ErrorCode.INVALID_INPUT,
-          'Cannot copy a directory into its own subdirectory',
-          copy.source,
-        ),
-      ),
-    };
-  }
-
-  const destExistedOriginally = await destExists(fs, validDest, 'copy');
-
-  const pending = destExistedOriginally && !overwrite;
-  return {
-    status: 'plan',
-    plan: { pair: copy, realSource, validDest, destExistedOriginally, pending },
-  };
-}
-
-async function executeCopy(
-  plan: CopyPlan,
-  ctx: Pick<ToolCtx, 'fs' | 'signal' | 'inputResponses'>,
-  pendingSorted: readonly string[],
-  overwrite: boolean,
-): Promise<PairExecResult<MoveItemResult>> {
-  if (plan.pending && !overwrite) {
-    const key = `confirm_${pendingSorted.indexOf(plan.validDest)}`;
-    const choice = readAcceptedChoice(ctx.inputResponses, key);
-    if (choice === 'skip') {
-      return { skipped: plan.pair.destination };
-    }
-    if (choice !== 'overwrite') {
-      throw new FsError(
-        ErrorCode.CANCELLED,
-        `Copy cancelled: overwrite of "${plan.pair.destination}" was declined or missing`,
-        plan.pair.destination,
-      );
-    }
-  }
-
-  // TOCTOU check before any mutation: a destination that did not exist when
-  // planned but exists now was created during the confirmation gap.
-  if ((await destExists(ctx.fs, plan.validDest, 'copy')) && !plan.destExistedOriginally) {
+  if (
+    !plan.isCaseOnlyRename &&
+    !plan.destExistedOriginally &&
+    (await destExists(ctx.fs, plan.validDest, op))
+  ) {
     throw new FsError(
       ErrorCode.CANCELLED,
-      `Copy cancelled: destination "${plan.pair.destination}" was created during confirmation.`,
+      `${VERB[op]} cancelled: destination "${plan.pair.destination}" was created during confirmation.`,
       plan.pair.destination,
     );
   }
 
   await ctx.fs.mkdir(dirname(plan.validDest), { recursive: true });
 
-  await ctx.fs.cp(plan.realSource, plan.validDest, {
-    recursive: true,
-    verbatimSymlinks: true,
-    preserveTimestamps: true,
-    force: true,
-  });
-
-  return { value: { from: plan.realSource, to: plan.validDest } };
+  if (op === 'move') {
+    await performRenameWithFallback(plan.opSource, plan.validDest, ctx.fs, plan.pair.source);
+    ctx.log?.('info', `move: ${plan.pair.source} -> ${plan.pair.destination}`, 'move');
+  } else {
+    await ctx.fs.cp(plan.opSource, plan.validDest, {
+      recursive: true,
+      verbatimSymlinks: true,
+      preserveTimestamps: true,
+      force: true,
+    });
+  }
+  return { value: { from: plan.opSource, to: plan.validDest } };
 }
 
 /**
@@ -299,17 +224,14 @@ async function handleMove(
   args: z.infer<typeof MoveInputSchema>,
   ctx: ToolCtx,
 ): Promise<z.infer<typeof MoveOutputSchema> | InputRequiredResult> {
-  const outcome = args.copy
-    ? await runOverPairs(args.moves, ctx, {
-        op: 'copy',
-        plan: (pair) => planCopy(pair, ctx.fs, args.overwrite),
-        execute: (plan, pendingSorted) => executeCopy(plan, ctx, pendingSorted, args.overwrite),
-      })
-    : await runOverPairs(args.moves, ctx, {
-        op: 'move',
-        plan: (move) => planMove(move, ctx.fs),
-        execute: (plan, pendingSorted) => executeMove(plan, ctx, pendingSorted),
-      });
+  const op: PairOp = args.copy ? 'copy' : 'move';
+  // `overwrite` is copy-only; move has no confirmation bypass.
+  const overwrite = args.copy && args.overwrite;
+  const outcome = await runOverPairs(args.moves, ctx, {
+    op,
+    plan: (pair) => planTransfer(op, pair, ctx.fs, overwrite),
+    execute: (plan, pendingSorted) => executeTransfer(op, plan, ctx, pendingSorted),
+  });
   if (isInputRequiredResult(outcome)) return outcome;
 
   const { results, skipped, failures } = outcome;
@@ -348,11 +270,11 @@ function buildSummary(
   return parts.join(' · ');
 }
 
-interface MoveSource {
-  /** Symlink preserved — the path actually handed to rename/cp/rm. */
-  renamePath: string;
+interface TransferSource {
   /** Symlink resolved — the identity used for every same-target comparison. */
-  realPath: string;
+  realSource: string;
+  /** The path the mutation runs on: symlink preserved for move, resolved for copy. */
+  opSource: string;
 }
 
 /**
@@ -360,16 +282,21 @@ interface MoveSource {
  * itself, or moving a symlink would rename the file it points at and leave the
  * link dangling. Every collision check must instead compare the resolved
  * target, or a link moved onto itself (or onto its own target) reads as a real
- * move and renames the link over that target, destroying it.
+ * move and renames the link over that target, destroying it. A copy reads
+ * through the link, so both views are the resolved one.
  */
-async function validateMoveSource(source: string, fs: ToolCtx['fs']): Promise<MoveSource> {
+async function validateTransferSource(
+  op: PairOp,
+  source: string,
+  fs: ToolCtx['fs'],
+): Promise<TransferSource> {
   try {
-    const realPath = await fs.pathGuard.validateExistingPath(source);
-    const renamePath = await fs.pathGuard.validatePathForDelete(source);
-    return { renamePath, realPath };
+    const realSource = await fs.pathGuard.validateExistingPath(source);
+    const opSource = op === 'move' ? await fs.pathGuard.validatePathForDelete(source) : realSource;
+    return { realSource, opSource };
   } catch (error) {
     if (isFsError(error)) throw error;
-    throw new FsError(ErrorCode.ACCESS_DENIED, `Move failed for ${source}`, source);
+    throw new FsError(ErrorCode.ACCESS_DENIED, `${VERB[op]} failed for ${source}`, source);
   }
 }
 


### PR DESCRIPTION
Two over-engineering findings from a repository audit. Both are
behavior-preserving on every reachable input; net **-148 lines**.

## 1. Dead Zod-issue pipeline (`core/errors.ts`, `core/schema.ts`)

`ProblemIssue`, `toProblemIssue`, `zodErrorToProblem`, `Problem.issues`,
`ErrorCode.VALIDATION_FAILED` and `resolveSuggestion` existed to carry Zod
issue detail into a `Problem`. Nothing could reach them:

- Tool arguments are validated by `safeParse` inside the SDK validator seam
  (`tools/define.ts`), which hands back `z.prettifyError`'s string rather
  than throwing.
- There is no `.parse()` call anywhere in `src/`.

So `classify()` never saw a `ZodError`. All of it is deleted, along with the
`zod` import from `errors.ts`. A comment at that branch records why the case
is absent and what to do if a `.parse()` is ever introduced.

The four `params: { rule, conflictsWith, suggestion }` blocks in
`validateReadRange` fed only that path. Each `suggestion` is folded into its
issue's own `message`, which is what `prettifyError` actually shows the
caller.

`VALIDATION_FAILED` was never on the wire — `PerFileErrorSchema.code` is
`z.string()`, and the instructions resource does not list it — so no client
contract changes.

## 2. Duplicated move/copy bodies (`tools/move.ts`)

`runOverPairs` already shared the *driver*, but the two plan/execute pairs it
drove were ~90% identical: validate source, validate destination, reject
self-targets, reject a destination inside the source, stat for the overwrite
confirmation, TOCTOU-recheck, `mkdir -p`, mutate.

`planMove`/`planCopy` merge into `planTransfer`, `executeMove`/`executeCopy`
into `executeTransfer`, `MovePlan`+`CopyPlan` into one `TransferPlan` whose
`opSource` is the link itself for a move and the resolved target for a copy.
The three genuine divergences are flags on the shared path:

| Divergence | How it is expressed |
| :--------- | :------------------ |
| Case-only rename | `isCaseOnlyRename && op === 'copy'` -> noop |
| Overwrite bypass | `overwrite = args.copy && args.overwrite` |
| The mutation | one `if (op === 'move')` at the end |

Three simplifications fell out, each identical on reachable input:

1. Copy's `plan.pending && !overwrite` — `pending` already encodes
   `!overwrite`; the second test is gone.
2. The TOCTOU guard short-circuits on `!destExistedOriginally` before the
   `destExists` stat, saving a syscall when the destination already existed.
3. Move's hand-rolled `IS_CASE_INSENSITIVE_FS` prefix fold is now the
   `isPathInsideDirectory` predicate copy always used.

### One deliberate behavior change

The shared containment guard uses copy's semantics. Move's old
`source + sep` prefix test never matched a bare filesystem root, so
`move C:\ -> C:\sub` passed the guard and would have recursed on the
cross-device copy fallback. It is unreachable today —
`validatePathForDelete` refuses an allowed root — but the stricter reading is
the correct one, so a new test pins **both** ops through the guard rather
than leaving the change silent. It asserts on `_meta.failures[0]`, since
`buildSummary`'s text block says only `move: nothing - 1 failed` and a text
assertion would pass without the guard firing.

Also widened: `validateTransferSource`'s non-`FsError` `ACCESS_DENIED`
fallback now covers copy, where it previously wrapped move only. Dead either
way (every `PathGuard` method throws `FsError`), and the wrapped message is
the better one.

## Verification

`node scripts/tasks.mjs` exits 0 — build, both type-checks, eslint, prettier,
knip, and 276 tests (275 before, +1 for the new guard pin).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015CZtVupVTyiemxRALyNJwG
