### PR TITLE
refactor: cut 26 over-engineering residues

### DIFF
--- a/__tests__/core-fs.test.ts
+++ b/__tests__/core-fs.test.ts
@@ -1,6 +1,6 @@
 import assert from 'node:assert/strict';
 import { writeFile } from 'node:fs/promises';
-import { dirname, join } from 'node:path';
+import { basename, dirname, join } from 'node:path';
 import { after, before, describe, it } from 'node:test';
 
 import { ErrorCode, isFsError } from '../src/core/errors.js';
@@ -206,6 +206,24 @@ describe('Core Filesystem (GuardedFileSystem + core search) Tests', () => {
       const txtResults = await searchFiles(searchDir, '**/*.txt', [], {}, ctx.pathGuard);
       assert.strictEqual(txtResults.results.length, 2);
       assert.ok(txtResults.results.every((r) => r.path.endsWith('.txt')));
+    });
+
+    it("TC-FUNC-039b: searchFiles sortBy 'name' orders by basename, not full path", async () => {
+      await writeTestFile(tmpDir, 'sort_dir/zzz/alpha.ts', '// a');
+      await writeTestFile(tmpDir, 'sort_dir/aaa/omega.ts', '// o');
+
+      const sortDir = join(tmpDir, 'sort_dir');
+      const byName = await searchFiles(sortDir, '**/*.ts', [], { sortBy: 'name' }, ctx.pathGuard);
+      assert.deepStrictEqual(
+        byName.results.map((r) => basename(r.path)),
+        ['alpha.ts', 'omega.ts'],
+      );
+
+      const byPath = await searchFiles(sortDir, '**/*.ts', [], {}, ctx.pathGuard);
+      assert.deepStrictEqual(
+        byPath.results.map((r) => basename(r.path)),
+        ['omega.ts', 'alpha.ts'],
+      );
     });
 
     it('TC-FUNC-040: searchContent matches literal patterns across files', async () => {

--- a/__tests__/helpers.ts
+++ b/__tests__/helpers.ts
@@ -21,7 +21,11 @@ import { PathGuard, resolveAllowedDirectoriesState } from '../src/core/path.js';
 import { createWatcherRegistry } from '../src/core/watcher-registry.js';
 import { createServer } from '../src/server.js';
 import type { FilesystemServerContext } from '../src/server.js';
+import { ALL_TOOLS } from '../src/tools/index.js';
 import { startHttpServer } from '../src/transport.js';
+
+/** Every registered tool's name - the inventory tests assert `tools/list` against. */
+export const ALL_REGISTERED_TOOL_NAMES: readonly string[] = ALL_TOOLS.map((t) => t.name);
 
 /** Create an isolated temp directory for a test. */
 export async function createTestRoot(): Promise<string> {

--- a/__tests__/http-server.test.ts
+++ b/__tests__/http-server.test.ts
@@ -8,9 +8,9 @@ import { json } from 'node:stream/consumers';
 import { afterEach, beforeEach, describe, it } from 'node:test';
 
 import { MAX_WATCHERS } from '../src/core/watcher-registry.js';
-import { ALL_REGISTERED_TOOL_NAMES } from '../src/tools/index.js';
 import { startHttpServer } from '../src/transport.js';
 import {
+  ALL_REGISTERED_TOOL_NAMES,
   bootHttpTest,
   cleanupTestRoot,
   createTestRoot,

--- a/__tests__/http-transport.test.ts
+++ b/__tests__/http-transport.test.ts
@@ -3,8 +3,8 @@ import { join } from 'node:path';
 import { after, before, describe, it } from 'node:test';
 
 import { INSTRUCTIONS_URI } from '../src/instructions.js';
-import { ALL_REGISTERED_TOOL_NAMES } from '../src/tools/index.js';
 import {
+  ALL_REGISTERED_TOOL_NAMES,
   cleanupTestRoot,
   createTestHttpHarness,
   createTestRoot,

--- a/__tests__/inspector-stdio.test.ts
+++ b/__tests__/inspector-stdio.test.ts
@@ -3,8 +3,13 @@ import { join } from 'node:path';
 import { after, before, describe, it } from 'node:test';
 
 import { normalizePath } from '../src/core/path-utils.js';
-import { ALL_REGISTERED_TOOL_NAMES, MUTATING_TOOL_NAMES } from '../src/tools/index.js';
-import { cleanupTestRoot, createTestRoot, getStdioServerCommand } from './helpers.js';
+import { MUTATING_TOOL_NAMES } from '../src/tools/index.js';
+import {
+  ALL_REGISTERED_TOOL_NAMES,
+  cleanupTestRoot,
+  createTestRoot,
+  getStdioServerCommand,
+} from './helpers.js';
 import { executeInspectorCli, inspectorSkipReason } from './inspector-harness.js';
 
 describe('Inspector CLI: Stdio Integration & Conformance', { skip: inspectorSkipReason() }, () => {

--- a/__tests__/smoke.test.ts
+++ b/__tests__/smoke.test.ts
@@ -3,8 +3,8 @@ import { join } from 'node:path';
 import { after, before, describe, it } from 'node:test';
 
 import { normalizePath } from '../src/core/path-utils.js';
-import { ALL_REGISTERED_TOOL_NAMES } from '../src/tools/index.js';
 import {
+  ALL_REGISTERED_TOOL_NAMES,
   cleanupTestRoot,
   createTestClientPair,
   createTestRoot,

--- a/__tests__/stdio.test.ts
+++ b/__tests__/stdio.test.ts
@@ -10,8 +10,8 @@ import { setTimeout } from 'node:timers/promises';
 
 import { isNodeError } from '../src/core/errors.js';
 import { buildFileResourceUri } from '../src/core/file-uri.js';
-import { ALL_REGISTERED_TOOL_NAMES } from '../src/tools/index.js';
 import {
+  ALL_REGISTERED_TOOL_NAMES,
   cleanupTestRoot,
   createRawStdioServer,
   createStdioClient,

--- a/__tests__/tools.test.ts
+++ b/__tests__/tools.test.ts
@@ -18,13 +18,9 @@ import { ResourceStore } from '../src/core/store.js';
 import { MAX_SEARCH_RESULTS } from '../src/core/util.js';
 import { createServer } from '../src/server.js';
 import { defineTool } from '../src/tools/define.js';
+import { ALL_TOOLS, MUTATING_TOOL_NAMES, registeredTools } from '../src/tools/index.js';
 import {
   ALL_REGISTERED_TOOL_NAMES,
-  ALL_TOOLS,
-  MUTATING_TOOL_NAMES,
-  registeredTools,
-} from '../src/tools/index.js';
-import {
   bootHttpTest,
   cleanupTestRoot,
   createElicitationClientPair,

--- a/docs/plan/2026-09-07-overeng-residue/overeng-residue.hunt.md
+++ b/docs/plan/2026-09-07-overeng-residue/overeng-residue.hunt.md
@@ -1,0 +1,117 @@
+# Bug hunt: overeng-residue
+
+**Subject** the uncommitted diff on `refactor/overeng-residue` vs `6cedcca9` — 26
+files, 329 insertions, 437 deletions. **Hunted** 2026-09-07.
+
+**Verdict: no defect found.** Every cut is behavior-identical on the paths this
+diff touches; two candidates were raised and both were killed by blind refuters.
+
+## Confirmed
+
+None.
+
+## Suspected
+
+None.
+
+## Killed
+
+Reported so a later hunt does not re-raise them.
+
+### 1. `edit.ts` builds a resource link on the no-match path
+
+`buildEditFileMetadata` ([`edit.ts:328`](../../../src/tools/edit.ts#L328)) now
+calls `buildWrittenFileMeta` unconditionally and blanks the result when
+`appliedEdits === 0`, where the old code short-circuited before building
+anything. Claim was that a side effect inside the link builder would now fire on
+an unmatched edit and on every dry run.
+
+**Killed** — the link builder never receives the store, so no store mutation is
+reachable by construction:
+
+```ts
+    resourceLink: resourceStore
+      ? buildFileResourceLink(validPath, mimeInfo.mimeType, bytesWritten)
+      : undefined,
+```
+
+`resourceStore` is consumed as a boolean gate and never passed onward
+([`file-uri.ts:113-115`](../../../src/core/file-uri.ts#L113-L115)).
+`buildFileResourceLink` and `buildFileResourceUri` are pure constructors. The
+extra work on the blanked path is a `Buffer.byteLength`, a MIME sniff, a line
+count, and two object literals, all discarded. No `notifications/resources/list_changed`
+can be emitted.
+
+### 2. `GuardedFileSystem.open` lost its write-capable branch
+
+[`fs.ts:268`](../../../src/core/fs.ts#L268) now always takes
+`validateExistingPath` and hardcodes `'r'`. Claim was a guard bypass or an EBADF
+on a write-intending caller, or a lost `--read-only` enforcement point.
+
+**Killed** on three counts:
+
+- The sole caller is read-only end to end —
+  [`replace-in-files.ts:374`](../../../src/tools/replace-in-files.ts#L374) opens,
+  stats, then hands the handle to `readFileBufferWithLimit`, which only calls
+  `handle.createReadStream(...)`. It passed `'r'` explicitly before the cut, so
+  the write branch had no reachable caller either.
+- Writes in that tool never go through `open`; they go through `atomicWriteFile`,
+  whose first act is `await pathGuard.validatePathForWrite(filePath)`
+  ([`fs.ts:66`](../../../src/core/fs.ts#L66)). The write guard is intact on the
+  only path that writes.
+- `validatePathForWrite` is not the `--read-only` enforcement point.
+  `registeredTools(readOnly)` ([`index.ts:41-44`](../../../src/tools/index.ts#L41-L44))
+  owns that gate; in read-only mode the mutating tools are never registered, so
+  no request reaches `open` or `writeFile`.
+
+## Checked and clean
+
+Each considered against the taxonomy and dismissed with the reason.
+
+| Cut | Why it is behavior-identical |
+| :--- | :--- |
+| `toPerFileError` returns `Problem` | `fromUnknown` already returns that exact shape via `build()`, with the same spread-conditional key omission; both allocate fresh. |
+| `PerPathError` / `DeleteFailure.error` → `Problem` | `code` narrows `string` → `ErrorCode` at compile time only; the wire schema `PerFileErrorSchema` keeps `code: z.string()` and validates unchanged. `readonly` is erased. |
+| `getFileType` → `resolveEntryType` | The isFile/isDirectory check order differs but never the result: `Stats` derives its type from `S_IFMT`, so exactly one predicate is true. `Stats` structurally satisfies `DirentLike`; `FileType` **is** `EntryType` (`fs.ts:28` aliases the import). |
+| `buildWrittenFileMeta` gate | `resourceStore !== undefined` (old patch.ts) vs truthiness (new): a `ResourceStore` instance is always truthy. `create.ts`'s `meta.resourceLink ? …` is truthy exactly when the store is, since `buildFileResourceLink` always returns an object. |
+| `annotations` param deleted | All six call sites already omitted it; the inlined literal is the same object the default produced. |
+| `createReadRangeFields` inlined | Same bounds, same messages, same four fields. TOOL-SURFACE-001/002 pin the emitted schema and pass. |
+| `maxBatch` deleted | Both callers passed only `{ extra }`; `DEFAULT_MAX_BATCH` is the value the fallback produced. |
+| `runOverPairs` → `runTransfers` | Body moved verbatim. Only substitution: `const verb = opts.op === 'copy' ? 'Copy' : 'Move'` → `VERB[op]`, which is `{ move: 'Move', copy: 'Copy' }` — identical strings. Plan-error rethrow, duplicate-destination fail-closed message, `confirm_${i}` indexing over the sorted pending list, progress tick, and `rethrowIfAborted` fold all unchanged. |
+| `ToolCtx.sessionId` / `.server` deleted | Neither was read. Every `.server` hit in `src/` is `mcp.server` (a different object) or `deps.server` (`ToolDeps`, kept). `resources.test.ts:30` builds a fake `ServerContext`, not a `ToolCtx`. |
+| `Problem.ioError` deleted | Zero callers. `ErrorCode.IO_ERROR` is still produced by `ERRNO_MAP` classification and still read by `fromUnknown`'s `shouldOverride`. |
+| `file-uri.ts`'s new imports | No cycle: `mime.ts`, `read.ts`, `store.ts` and `schema.ts` do not import `file-uri.ts`. `FileKind` and `ResourceStore` are type-only imports and erase. |
+| `fmt.ts` gains `diff` | `src/core/` already imports `ignore`, `@adguard/re2-wasm`, and `zod`. No import-boundary lint covers `src/core/**`. |
+
+## Behavior that did change, by design
+
+`searchFiles` `sortBy: 'name'` now uses `basename()` instead of splitting on
+`[/\\]`. On POSIX a filename containing a literal `\` sorts differently — the old
+comparator treated the backslash as a separator, which was wrong. The plan calls
+this a fix, not a preservation. On Windows the two are identical, because
+`path.win32.basename` splits on both separators.
+
+## Coverage
+
+**Read in full**: the complete diff of all 19 `src/` files at `-U8`, plus the
+whole of `src/tools/move.ts`'s new `runTransfers` and the surrounding
+`planTransfer`/`executeTransfer`; the complete diff of all 7 test files.
+
+**Blast radius opened**: `src/core/store.ts` (link-builder purity),
+`src/core/path.ts` (`validatePathForWrite`, `--read-only`), `src/core/read.ts`
+(import chain and `readFileBufferWithLimit`), `src/core/glob.ts`
+(`resolveEntryType`, `DirentLike`), `src/core/mime.ts` and `src/core/schema.ts`
+(cycle check only), `eslint.config.mjs`, `knip.json`, `tsconfig.json`.
+
+**Not audited**: the unchanged bodies of the large files this diff only touches in
+part — `replace-in-files.ts`, `read.ts`, `define.ts`, `delete-file.ts`,
+`tools.test.ts` — read only far enough to judge the changed contract, per scope.
+The security core (`path.ts`'s containment, the sensitive denylist, ADS
+stripping, `http-policy.ts`) is unchanged by this diff and was not re-audited.
+
+**Taken on trust**: that `diff` v9's `diffLines` and `createTwoFilesPatch` return
+synchronously — the moved comments assert it, the behavior is unchanged by this
+diff, and 277 tests exercise both.
+
+**Not run**: this is a static hunt. The gate (`node scripts/tasks.mjs`, exit 0,
+277 pass) was run by run-plan, not by the hunt.

--- a/docs/plan/2026-09-07-overeng-residue/overeng-residue.plan-hunt.md
+++ b/docs/plan/2026-09-07-overeng-residue/overeng-residue.plan-hunt.md
@@ -1,0 +1,108 @@
+# Plan hunt: overeng-residue
+
+**Plan** [`overeng-residue.plan.md`](overeng-residue.plan.md), written against
+`6cedcca9`. **Hunted** 2026-09-07 at `6cedcca9`, clean tree.
+
+5 candidates raised, 5 refuted blind (one refuter each, none saw the hunter's
+reasoning). **1 confirmed, 4 killed.**
+
+## Confirmed
+
+### 1. Step 13 keeps `PairFailureItem`, which its own Verify then fails on
+
+**Where** step 13, [`overeng-residue.plan.md`](overeng-residue.plan.md) — the
+"Keep in `batch.ts`" list and the import line two paragraphs below it.
+
+The step says:
+
+> Keep in `batch.ts`: `PairFailureItem` ([`:17-27`]) — it is the wire type
+> `move.ts` still needs
+
+and then:
+
+> `move.ts`'s import line becomes
+> `import { isTotalFailure, type PairFailureItem } from './batch.js';` — or drop
+> `PairFailureItem` entirely if `MoveFailureItem` already covers every use, which
+> it should.
+
+Both halves are wrong, and they contradict each other.
+
+**The justification is false.** `move.ts` does not import `PairFailureItem` today
+and will not after the fold. Its only type import from `batch.ts` is
+[`move.ts:22`](../../../src/tools/move.ts#L22):
+
+```ts
+import type { PairExecResult, PairPlanResult } from './batch.js';
+```
+
+`move.ts` already has its own wire type at
+[`move.ts:51`](../../../src/tools/move.ts#L51) —
+`type MoveFailureItem = z.infer<typeof MoveFailureItemSchema>;` — which step 13
+itself uses for every replacement type.
+
+**Every remaining reference dies in the same step.** All five occurrences of
+`PairFailureItem` in the repo are in `batch.ts`, and four of them sit inside code
+step 13 deletes or moves:
+
+| Line | Context | Fate under step 13 |
+| :--- | :--- | :--- |
+| [`batch.ts:18`](../../../src/tools/batch.ts#L18) | the interface | kept (per the step) |
+| [`batch.ts:123`](../../../src/tools/batch.ts#L123) | `PairPlanResult` | deleted |
+| [`batch.ts:133`](../../../src/tools/batch.ts#L133) | `PairBatchOutcome` | deleted |
+| [`batch.ts:164`](../../../src/tools/batch.ts#L164) | `pairFailure` return | moved to `move.ts` |
+| [`batch.ts:206`](../../../src/tools/batch.ts#L206) | `runOverPairs` local | deleted |
+
+`isTotalFailure`, the one kept function that could rescue it, is typed on
+`readonly unknown[]` ([`batch.ts:152-155`](../../../src/tools/batch.ts#L152-L155))
+and never names it.
+
+**knip fails on the result.** `knip.json` sets only `entry`, `project`, and
+`ignoreDependencies` — no `rules`, no `ignoreIssues`, no
+`ignoreExportsUsedInFile` — so knip 6's default issue set applies, and
+`types` (unused exported types) is **not** in its default exclusion list. Only a
+reference from a *used exported function* rescues a type; `pairFailure`'s return
+annotation is the sole thing rescuing `PairFailureItem` today, and step 13 moves
+`pairFailure` out. `check:static` runs `knip` unflagged, so
+`node scripts/tasks.mjs` — step 13's own Verify — exits non-zero.
+
+The step's own fallback does not save it either: an imported-but-unused type in
+`move.ts` trips `eslint . --max-warnings=0`.
+
+**Fix**: move `PairFailureItem` from step 13's keep list to its delete list, and
+strike the "or drop it entirely" alternative so the step reads as one
+deterministic instruction. `move.ts` needs no type import from `batch.ts`
+afterwards — only `isTotalFailure`.
+
+## Killed
+
+Reported for the record; no action.
+
+| # | Candidate | Why it died |
+| :--- | :--- | :--- |
+| 2 | Step 9 leaves the `patch.ts` `resourceUri` narrowing unspecified | `def.output` is compile-time only — no tool publishes an `outputSchema` ([`define.ts:524-531`](../../../src/tools/define.ts#L524-L531), pinned by `tools.test.ts`'s TOOL-SURFACE-001), so every narrowing emits byte-identical `_meta`. `no-non-null-assertion` is already an error under `strictTypeChecked`, ruling out the one form that would differ. |
+| 3 | Step 8 puts `diff` into `src/core/fmt.ts` | `src/core/` is already where dependency-carrying primitives live — `glob.ts` imports `ignore`, `search.ts` imports `@adguard/re2-wasm`, `schema.ts` imports `zod`. The repo's only import-boundary lint (`project/registrar-boundaries`) constrains the tool layer, not core. |
+| 4 | Step 5 says "several already do" of the `ALL_TOOLS` import | A miscount (only `tools.test.ts` has it), but no executor action depends on it: the step lists the exact import line in all six files and makes editing that line mandatory. |
+| 5 | Step 11 hedges on removing the `fsConstants` import | `tsconfig.json` pins `noUnusedLocals` with `noEmitOnError`, so a leftover import is a hard build failure, and the plan states the delegate-to-eslint convention twice elsewhere (steps 1 and 13). |
+
+## Minors — prose accuracy, not dead steps
+
+Two false statements in **Current state** that no step depends on. Fix them while
+fixing finding 1, or leave them.
+
+1. Step 8's rationale says "`diff.ts` and `move.ts` do" import `../core/fmt.js`.
+   `move.ts` does; **`diff.ts` does not**. The `fmt.ts` consumers are `cli.ts`,
+   `cli-help.ts`, `define.ts`, `delete-file.ts`, `move.ts`,
+   `replace-in-files.ts`, `search-content.ts`, `search-files.ts`.
+2. Step 5's "several already do" — one file, `tools.test.ts:23`.
+
+## Verdict
+
+One confirmed dead step. Steps 1–12 are clean.
+
+## Resolution — 2026-09-07
+
+Finding 1 fixed in the plan: `PairFailureItem` moved to step 13's delete list,
+the "or drop it entirely" alternative struck, `move.ts`'s new import line fixed
+to `import { isTotalFailure } from './batch.js';`, and `PairFailureItem` added to
+the Done checklist's grep. Both Minors fixed. The step-13 defect marker is
+removed. Plan cleared for run-plan.

--- a/docs/plan/2026-09-07-overeng-residue/overeng-residue.plan.md
+++ b/docs/plan/2026-09-07-overeng-residue/overeng-residue.plan.md
@@ -1,0 +1,1106 @@
+# Plan: cut the 16 verified over-engineering residues left by the 2026-09-07 audit
+
+> **Executor rules**: work the steps in order. Run every Verify command and
+> confirm its expected result before moving on. On any STOP condition, stop and
+> report the condition, the step, and the evidence.
+>
+> **Written against** commit `6cedcca9`, 2026-09-07.
+> **Drift check (run first)**:
+> `git diff --stat 6cedcca9..HEAD -- src/ __tests__/`
+> Its file list is what narrows the excerpt match: compare
+> [Current state](#current-state) against the live code for every file it flags.
+> A mismatch is a [STOP](#stop) condition.
+
+## Goal
+
+A full-repo over-engineering audit confirmed 16 behavior-preserving cuts sitting
+on top of commit `8524d341`: one generic driver with a single instantiation, one
+unreachable write branch, four hand-declared copies of one error shape, three
+copies of a post-write metadata block, two copies of a diff-stat loop, two copies
+of a `createTwoFilesPatch` call, and six pieces of dead surface (unread context
+fields, unpassed options, a one-caller factory, a test-only export). Every cut is
+a deletion or a fold — no new behavior, no new features, no schema change on the
+wire.
+
+The cost today is read cost: a maintainer tracing `move`'s failure path reads a
+three-type-parameter driver in `batch.ts` that exists for one call site, and four
+declarations of `{code, message, path?, suggestion?}` that are the same type.
+When this lands, the tool layer has one error shape, one diff-stat helper, one
+post-write metadata builder, and `batch.ts` holds only the path-batch driver two
+tools actually share.
+
+Requirements covered: none, this is a cleanup.
+
+## Current state
+
+Every cut's exact code as it exists at `6cedcca9`.
+
+### The error shape, declared four times
+
+[`src/core/errors.ts:20-32`](../../../src/core/errors.ts#L20-L32) — the private
+twin and the exported original are field-for-field identical:
+
+```ts
+interface PerFileError {
+  readonly code: ErrorCode;
+  readonly message: string;
+  readonly path?: string;
+  readonly suggestion?: string;
+}
+
+export interface Problem {
+  readonly code: ErrorCode;
+  readonly message: string;
+  readonly path?: string;
+  readonly suggestion?: string;
+}
+```
+
+[`src/core/errors.ts:76-90`](../../../src/core/errors.ts#L76-L90) — the rebuild
+that copies a `Problem` into the twin field by field:
+
+```ts
+  toPerFileError(
+    error: unknown,
+    defaultCode: ErrorCode = ErrorCode.UNKNOWN,
+    path?: string,
+  ): PerFileError {
+    const problem = Problem.fromUnknown(error, defaultCode, path);
+    return {
+      code: problem.code,
+      message: problem.message,
+      ...(problem.path !== undefined ? { path: problem.path } : {}),
+      ...(problem.suggestion !== undefined ? { suggestion: problem.suggestion } : {}),
+    };
+  },
+```
+
+`Problem.fromUnknown` already returns exactly that shape via its own `build()`
+([`errors.ts:39-46`](../../../src/core/errors.ts#L39-L46)), so the rebuild is a
+copy with no transform.
+
+[`src/tools/batch.ts:10-15`](../../../src/tools/batch.ts#L10-L15) — third copy,
+consumed only by `PerPathResult<T>` at
+[`batch.ts:29`](../../../src/tools/batch.ts#L29):
+
+```ts
+interface PerPathError {
+  code: ErrorCode;
+  message: string;
+  path?: string;
+  suggestion?: string;
+}
+```
+
+[`src/tools/delete-file.ts:76-84`](../../../src/tools/delete-file.ts#L76-L84) —
+fourth copy, inline:
+
+```ts
+interface DeleteFailure {
+  path: string;
+  error: {
+    code: string;
+    message: string;
+    path?: string;
+    suggestion?: string;
+  };
+}
+```
+
+`Problem` is already imported by both files
+([`batch.ts:4`](../../../src/tools/batch.ts#L4),
+[`delete-file.ts:9-16`](../../../src/tools/delete-file.ts#L9-L16)).
+
+> `PairFailureItem.error` at
+> [`batch.ts:21-26`](../../../src/tools/batch.ts#L21-L26) is a **wire** type
+> (`code: string`, explicit `| undefined` on the optionals) mirroring
+> `PerFileErrorSchema`. It is NOT a fifth copy — step 7 leaves it alone. (Step 13
+> deletes it for an unrelated reason: it becomes unreferenced when the pair
+> driver moves.)
+
+### The pair driver with one instantiation
+
+[`src/tools/batch.ts:115-134`](../../../src/tools/batch.ts#L115-L134) and
+[`batch.ts:161-302`](../../../src/tools/batch.ts#L161-L302) — `PairPlan`,
+`PairPlanResult`, `PairExecResult`, `PairBatchOutcome`, `RunOverPairsOptions`,
+`pairFailure`, and `runOverPairs<TItem, TPlan, TResult>`.
+
+The sole instantiation is
+[`move.ts:230-234`](../../../src/tools/move.ts#L230-L234):
+
+```ts
+  const outcome = await runOverPairs(args.moves, ctx, {
+    op,
+    plan: (pair) => planTransfer(op, pair, ctx.fs, overwrite),
+    execute: (plan, pendingSorted) => executeTransfer(op, plan, ctx, pendingSorted),
+  });
+```
+
+with `TItem = { source, destination }`, `TPlan = TransferPlan`
+([`move.ts:72-92`](../../../src/tools/move.ts#L72-L92)), `TResult =
+MoveItemResult` ([`move.ts:65`](../../../src/tools/move.ts#L65)). `move.ts` also
+imports the two result types at
+[`move.ts:22`](../../../src/tools/move.ts#L22).
+
+`isTotalFailure` at
+[`batch.ts:148-159`](../../../src/tools/batch.ts#L148-L159) takes **either**
+count shape and is used by six tools — it stays in `batch.ts`, and its doc
+comment mentions `runOverPairs`, so the comment needs a word changed.
+
+`runOverPaths` at [`batch.ts:56-113`](../../../src/tools/batch.ts#L56-L113) has
+five callers and stays untouched.
+
+### The unreachable write branch
+
+[`src/core/fs.ts:281-296`](../../../src/core/fs.ts#L281-L296):
+
+```ts
+  async open(
+    filePath: string,
+    flags: string | number,
+    mode?: string | number,
+  ): Promise<FileHandle> {
+    // Only a plain read-only open ('r' / O_RDONLY) uses the existing-path guard.
+    // Every other flag (write, append, read-write, sync, numeric) is treated as
+    // write-capable and routed through the stricter write guard.
+    const isReadOnly = flags === 'r' || flags === fsConstants.O_RDONLY;
+    const validPath = isReadOnly
+      ? await this.pathGuard.validateExistingPath(filePath)
+      : await this.pathGuard.validatePathForWrite(filePath);
+    return fsOpen(validPath, flags, mode);
+  }
+```
+
+The only caller is
+[`replace-in-files.ts:375`](../../../src/tools/replace-in-files.ts#L375):
+
+```ts
+  await using fileHandle = await ctx.fs.open(validPath, 'r');
+```
+
+`fsConstants` may become unused in `fs.ts` after the cut — check before deleting
+its import.
+
+### `getFileType` duplicating `resolveEntryType`
+
+[`src/core/fs.ts:123-128`](../../../src/core/fs.ts#L123-L128):
+
+```ts
+export function getFileType(stats: Stats): FileType {
+  if (stats.isFile()) return 'file';
+  if (stats.isDirectory()) return 'directory';
+  if (stats.isSymbolicLink()) return 'symlink';
+  return 'other';
+}
+```
+
+[`src/core/glob.ts:16-27`](../../../src/core/glob.ts#L16-L27):
+
+```ts
+export interface DirentLike {
+  isDirectory(): boolean;
+  isFile(): boolean;
+  isSymbolicLink(): boolean;
+}
+
+export function resolveEntryType(dirent: DirentLike): EntryType {
+  if (dirent.isDirectory()) return 'directory';
+  if (dirent.isFile()) return 'file';
+  if (dirent.isSymbolicLink()) return 'symlink';
+  return 'other';
+}
+```
+
+The check order differs but never the result — `Stats` reports exactly one type.
+`Stats` structurally satisfies `DirentLike`. The return types are the same type:
+[`fs.ts:28`](../../../src/core/fs.ts#L28) is
+`import type { EntryType as FileType } from './primitives.js'`, and
+[`schema.ts:36-38`](../../../src/core/schema.ts#L36-L38) builds `FileType` from
+the same `ENTRY_TYPES`.
+
+Three callers: [`stat.ts:70`](../../../src/tools/stat.ts#L70),
+[`delete-file.ts:181`](../../../src/tools/delete-file.ts#L181),
+[`delete-file.ts:230`](../../../src/tools/delete-file.ts#L230).
+
+### The post-write metadata block, written three times
+
+[`src/tools/patch.ts:51-71`](../../../src/tools/patch.ts#L51-L71):
+
+```ts
+function buildPatchMeta(
+  validPath: string,
+  patched: string,
+  resourceStore: ToolCtx['resourceStore'],
+): PatchMeta {
+  const bytesWritten = Buffer.byteLength(patched, 'utf-8');
+  const mimeInfo = detectMimeFromContent(validPath, patched);
+  const resourceUri = buildFileResourceUri(validPath);
+  const link =
+    resourceStore !== undefined
+      ? buildFileResourceLink(validPath, mimeInfo.mimeType, bytesWritten)
+      : undefined;
+  return {
+    size: bytesWritten,
+    lineCount: countLines(patched),
+    mimeType: mimeInfo.mimeType,
+    kind: mimeInfo.kind,
+    resourceUri,
+    link,
+  };
+}
+```
+
+[`src/tools/edit.ts:343-368`](../../../src/tools/edit.ts#L343-L368) — same five
+steps, with the `appliedEdits > 0` gate:
+
+```ts
+function buildEditFileMetadata(
+  content: string,
+  validPath: string,
+  appliedEdits: number,
+  resourceStore: ResourceStore | undefined,
+): EditFileMetadata {
+  const bytesWritten = Buffer.byteLength(content, 'utf-8');
+  const lineCount = countLines(content);
+  const mimeInfo = detectMimeFromContent(validPath, content);
+  // Omitted rather than empty-stringed when nothing matched: `""` satisfied the
+  // schema's `string` and then failed every resources/read a client tried it on.
+  const resourceUri = appliedEdits > 0 ? buildFileResourceUri(validPath) : undefined;
+  const resourceLink =
+    appliedEdits > 0 && resourceStore
+      ? buildFileResourceLink(validPath, mimeInfo.mimeType, bytesWritten)
+      : undefined;
+  return { /* … */ };
+}
+```
+
+[`src/tools/create.ts:98-121`](../../../src/tools/create.ts#L98-L121) — the same
+steps inline inside the per-file callback:
+
+```ts
+        const bytesWritten = Buffer.byteLength(content, 'utf-8');
+        const lineCount = countLines(content);
+        const mimeInfo = detectMimeFromContent(validPath, content);
+
+        const resourceUri = buildFileResourceUri(validPath);
+        const file: CreateFileResult = { /* … */ };
+
+        return ctx.resourceStore
+          ? {
+              file,
+              resourceLink: buildFileResourceLink(validPath, mimeInfo.mimeType, bytesWritten),
+            }
+          : { file };
+```
+
+All three already import from
+[`src/core/file-uri.ts`](../../../src/core/file-uri.ts) — that is the helper's
+home.
+
+> The `appliedEdits > 0` gate is load-bearing and verified: an edit that matched
+> nothing must emit **no** `resourceUri` and **no** link. It becomes a parameter,
+> never a dropped condition.
+
+### The diff-stat loop, written twice
+
+[`src/tools/edit.ts:179-191`](../../../src/tools/edit.ts#L179-L191) —
+module-local:
+
+```ts
+function computeDiffStats(
+  original: string,
+  modified: string,
+): { linesAdded: number; linesRemoved: number } {
+  // diffLines returns the change list synchronously on diff v9.
+  let linesAdded = 0;
+  let linesRemoved = 0;
+  for (const part of diffLines(original, modified)) {
+    if (part.added) linesAdded += part.count;
+    else if (part.removed) linesRemoved += part.count;
+  }
+  return { linesAdded, linesRemoved };
+}
+```
+
+[`src/tools/diff.ts:61-67`](../../../src/tools/diff.ts#L61-L67) — the same loop
+inline:
+
+```ts
+  // diffLines returns the change list synchronously; count added/removed lines.
+  let linesAdded = 0;
+  let linesRemoved = 0;
+  for (const part of diffLines(contentA, contentB)) {
+    if (part.added) linesAdded += part.count;
+    else if (part.removed) linesRemoved += part.count;
+  }
+```
+
+Neither `edit.ts` nor `diff.ts` imports
+[`src/core/fmt.ts`](../../../src/core/fmt.ts) today — eight other files do
+(`cli.ts`, `cli-help.ts`, `define.ts`, `delete-file.ts`, `move.ts`,
+`replace-in-files.ts`, `search-content.ts`, `search-files.ts`), which is what
+makes it the shared home. `diff` is already a production dependency, and
+`src/core/` already carries package imports (`glob.ts` → `ignore`, `search.ts` →
+`@adguard/re2-wasm`, `schema.ts` → `zod`), so this adds no new dependency and
+crosses no lint boundary.
+
+> [`patch.ts:75-87`](../../../src/tools/patch.ts#L75-L87) counts `+`/`-` prefixes
+> off a **parsed patch**, not `diffLines`. Different input, not a third copy —
+> leave it.
+
+### The `createTwoFilesPatch` call, written twice
+
+[`src/tools/edit.ts:425-434`](../../../src/tools/edit.ts#L425-L434):
+
+```ts
+      const label = basename(validPath);
+      // createTwoFilesPatch returns the unified diff string synchronously on
+      // diff v9 (the { callback } option fires via setTimeout and returns undefined).
+      editResult.diff = createTwoFilesPatch(
+        label,
+        label,
+        content,
+        editResult.content,
+        'Original',
+        'Modified',
+      );
+```
+
+[`src/tools/replace-in-files.ts:400-412`](../../../src/tools/replace-in-files.ts#L400-L412):
+
+```ts
+  const header = toPosixRelative(summary.root, params.filePath);
+
+  // createTwoFilesPatch returns the unified diff string synchronously on
+  // diff v9 (the { callback } option fires via setTimeout and returns undefined).
+  const patch = createTwoFilesPatch(
+    header,
+    header,
+    params.originalContent,
+    params.updatedContent,
+    'Original',
+    'Modified',
+  );
+```
+
+Same args, same headers, same comment — only the label differs.
+
+> [`diff.ts:51-59`](../../../src/tools/diff.ts#L51-L59) passes **two different**
+> file names, headers `'a'`/`'b'`, and a `{ context }` option. Not a duplicate —
+> leave it.
+
+### The hand-rolled basename
+
+[`src/core/search.ts:311-321`](../../../src/core/search.ts#L311-L321):
+
+```ts
+  if (options.sortBy === 'name') {
+    results.sort((a, b) => {
+      const aName = a.path.split(/[/\\]/).pop() ?? '';
+      const bName = b.path.split(/[/\\]/).pop() ?? '';
+      return aName.localeCompare(bName);
+    });
+  } else {
+    results.sort((a, b) => a.path.localeCompare(b.path));
+  }
+```
+
+`String.prototype.split` never returns an empty array, so `?? ''` is dead; and
+splitting on `\` is wrong on POSIX, where `\` is a legal filename character.
+`node:path` is not yet imported by
+[`search.ts:1-11`](../../../src/core/search.ts#L1-L11) — the `basename` import is
+new.
+
+`sortBy: 'name'` has **zero** test coverage today: the only `searchFiles` test is
+[`core-fs.test.ts:193-209`](../../../__tests__/core-fs.test.ts#L193-L209)
+(TC-FUNC-039), which passes `{}`. Step 12 adds one.
+
+### Dead surface
+
+| Location | What is dead |
+| :--- | :--- |
+| [`define.ts:46`](../../../src/tools/define.ts#L46) | `ToolCtx.sessionId` — assigned at [`:179`](../../../src/tools/define.ts#L179), read by nothing |
+| [`define.ts:83`](../../../src/tools/define.ts#L83) | `ToolCtx.server` — assigned at [`:156`](../../../src/tools/define.ts#L156) and [`:189`](../../../src/tools/define.ts#L189), read by nothing |
+| [`schema.ts:281`](../../../src/core/schema.ts#L281) | `singleOrBatchPathsInput`'s `maxBatch` option — never passed |
+| [`file-uri.ts:47`](../../../src/core/file-uri.ts#L47) | `annotations` param — never passed by any of 6 call sites |
+| [`index.ts:41`](../../../src/tools/index.ts#L41) | `ALL_REGISTERED_TOOL_NAMES` — test-only export |
+| [`schema.ts:189`](../../../src/core/schema.ts#L189) | `createReadRangeFields` factory — one caller |
+| [`errors.ts:57`](../../../src/core/errors.ts#L57) | `Problem.ioError` factory — zero callers |
+
+Grep evidence recorded at `6cedcca9`:
+
+- `sessionId`: only `define.ts:46`, `define.ts:179`, and
+  [`resources.test.ts:30`](../../../__tests__/resources.test.ts#L30) — the test
+  builds a fake `ServerContext`, not a `ToolCtx`, so it is unaffected.
+- `.server` under `src/tools/`: `define.ts:156`, `define.ts:175`, `define.ts:189`,
+  `define.ts:540`, `index.ts:65`. Lines 175 and 540 read **`deps.server`**
+  (`ToolDeps`), a different object. `ToolDeps.server` stays.
+- `maxBatch`: both callers pass only `{ extra }` —
+  [`read.ts:48`](../../../src/tools/read.ts#L48),
+  [`stat.ts:26`](../../../src/tools/stat.ts#L26).
+- `annotations` on the two link builders: not passed at
+  [`create.ts:118`](../../../src/tools/create.ts#L118),
+  [`edit.ts:358`](../../../src/tools/edit.ts#L358),
+  [`patch.ts:62`](../../../src/tools/patch.ts#L62),
+  [`read.ts:522`](../../../src/tools/read.ts#L522),
+  [`replace-in-files.ts:632`](../../../src/tools/replace-in-files.ts#L632), or
+  the internal call at
+  [`file-uri.ts:58`](../../../src/core/file-uri.ts#L58).
+- `ALL_REGISTERED_TOOL_NAMES`: 14 references, all in tests —
+  `http-server.test.ts:11,199`, `http-transport.test.ts:6,37`,
+  `inspector-stdio.test.ts:6,81,82`, `smoke.test.ts:6,36,39`,
+  `stdio.test.ts:13,59`, `tools.test.ts:22,231`. `knip` does not flag it because
+  `knip.json`'s entry glob is `__tests__/**/*.test.ts`.
+- `ioError`: definition only (`errors.ts:57`), plus the compiled
+  `dist/core/errors.d.ts` — no call site anywhere in `src/`, `__tests__/`, or
+  `scripts/`.
+
+`createReadRangeFields`'s one caller passes four fixed strings —
+[`read.ts:41-47`](../../../src/tools/read.ts#L41-L47):
+
+```ts
+const readRangeFields = createReadRangeFields({
+  head: 'Return first N lines',
+  tail: 'Return last N lines',
+  startLine: 'Start line (1-indexed)',
+  endLine: 'End line (1-indexed)',
+});
+```
+
+The TODO above it at
+[`schema.ts:180-181`](../../../src/core/schema.ts#L180-L181) already says so.
+
+### Conventions to match
+
+- **Comments earn their place.** This repo writes a comment when the code is
+  surprising and nowhere else — see the TOCTOU note at
+  [`move.ts:186-188`](../../../src/tools/move.ts#L186-L188) and the URI-case note
+  at [`file-uri.ts:35-41`](../../../src/core/file-uri.ts#L35-L41). When a cut
+  removes a code path, remove its comment too; when a cut moves code, the comment
+  moves with it.
+- **Optional properties are spread, never set to `undefined`** — the codebase runs
+  `exactOptionalPropertyTypes`. Exemplar:
+  [`errors.ts:40-45`](../../../src/core/errors.ts#L40-L45).
+- **Formatting is Prettier's** — never hand-format; `node scripts/tasks.mjs fix`
+  settles it.
+
+## Commands
+
+| Purpose | Command | Expected on success |
+| :--- | :--- | :--- |
+| Static checks | `node scripts/tasks.mjs --quick` | exit 0; build, both type-checks, eslint, prettier, knip all clean |
+| Tests | `node scripts/tasks.mjs test` | exit 0; `pass 276 fail 0` (277 from step 12 on) |
+| Full gate | `node scripts/tasks.mjs` | exit 0 |
+| Format + lint-fix | `node scripts/tasks.mjs fix` | exit 0 |
+
+Baseline at `6cedcca9`: `tests 276`, `suites 61`, `pass 276`, `fail 0`.
+
+## Scope
+
+**In scope** — the only files to modify:
+
+- [`src/core/errors.ts`](../../../src/core/errors.ts)
+- [`src/core/fs.ts`](../../../src/core/fs.ts)
+- [`src/core/file-uri.ts`](../../../src/core/file-uri.ts)
+- [`src/core/fmt.ts`](../../../src/core/fmt.ts)
+- [`src/core/schema.ts`](../../../src/core/schema.ts)
+- [`src/core/search.ts`](../../../src/core/search.ts)
+- [`src/tools/batch.ts`](../../../src/tools/batch.ts)
+- [`src/tools/create.ts`](../../../src/tools/create.ts)
+- [`src/tools/define.ts`](../../../src/tools/define.ts)
+- [`src/tools/delete-file.ts`](../../../src/tools/delete-file.ts)
+- [`src/tools/diff.ts`](../../../src/tools/diff.ts)
+- [`src/tools/edit.ts`](../../../src/tools/edit.ts)
+- [`src/tools/index.ts`](../../../src/tools/index.ts)
+- [`src/tools/move.ts`](../../../src/tools/move.ts)
+- [`src/tools/patch.ts`](../../../src/tools/patch.ts)
+- [`src/tools/read.ts`](../../../src/tools/read.ts)
+- [`src/tools/replace-in-files.ts`](../../../src/tools/replace-in-files.ts)
+- [`src/tools/stat.ts`](../../../src/tools/stat.ts)
+- [`__tests__/core-fs.test.ts`](../../../__tests__/core-fs.test.ts) — step 12 only
+- [`__tests__/http-server.test.ts`](../../../__tests__/http-server.test.ts),
+  [`__tests__/http-transport.test.ts`](../../../__tests__/http-transport.test.ts),
+  [`__tests__/inspector-stdio.test.ts`](../../../__tests__/inspector-stdio.test.ts),
+  [`__tests__/smoke.test.ts`](../../../__tests__/smoke.test.ts),
+  [`__tests__/stdio.test.ts`](../../../__tests__/stdio.test.ts),
+  [`__tests__/tools.test.ts`](../../../__tests__/tools.test.ts) — step 5 only
+
+**Files out of scope** — leave alone even though they look related:
+
+- [`src/cli.ts`](../../../src/cli.ts),
+  [`src/cli-help.ts`](../../../src/cli-help.ts),
+  [`README.md`](../../../README.md) — the `--safe` alias of `--read-only` was
+  considered and **excluded**: it is a documented public CLI flag
+  (`README.md:368`, `cli-help.ts:28`), so removing it is a breaking change, not a
+  behavior-preserving cut.
+- [`src/core/store.ts`](../../../src/core/store.ts),
+  [`src/core/page-store.ts`](../../../src/core/page-store.ts) — merging the two
+  stores was adversarially refuted twice (client-visible ISO TTL vs injectable
+  numeric clock, byte-metered vs count-only eviction, test-pinned prune
+  coalescing). A generic replacement needs knobs costing more than the dedup
+  saves.
+- [`src/core/path.ts`](../../../src/core/path.ts),
+  [`src/core/http-policy.ts`](../../../src/core/http-policy.ts) — the security
+  core. PathGuard's dual lexical+realpath containment, the sensitive denylist,
+  and NTFS ADS stripping were all verified load-bearing. Do not "simplify" them.
+- `delete-file.ts`'s plan/execute pipeline beyond the two `getFileType` call
+  sites and the `DeleteFailure.error` type — routing `delete` through the pair
+  driver was refuted twice: its output shaping (input-ordered rows,
+  noop→`deleted:true`, requested-vs-resolved path fallback) cannot be expressed
+  by `PairBatchOutcome`, and the swap silently changes plan-error, duplicate-key,
+  pending-dedupe, and noop semantics on an irreversible tool with test-pinned
+  behavior (TC-FUNC-068/069/069b).
+- [`package.json`](../../../package.json),
+  [`server.json`](../../../server.json) — versions are bumped only by the
+  Release workflow.
+- [`dist/`](../../../dist) — build output; `npm run build` regenerates it.
+
+## Steps
+
+Steps 1–6 are independent dead-surface deletions; 7 unifies the error shape;
+8–12 fold the duplicated blocks; 13 is the pair-driver fold and lands last
+because it is the largest diff.
+
+Run `node scripts/tasks.mjs fix` before each Verify if Prettier complains.
+
+### 1. Delete the two unread `ToolCtx` fields
+
+In [`src/tools/define.ts`](../../../src/tools/define.ts):
+
+- Delete `readonly sessionId?: string;` at
+  [`:46`](../../../src/tools/define.ts#L46) and its spread
+  `...(ctx.sessionId ? { sessionId: ctx.sessionId } : {}),` at
+  [`:179`](../../../src/tools/define.ts#L179).
+- Delete `readonly server?: McpServer;` at
+  [`:83`](../../../src/tools/define.ts#L83) and both assignments
+  `server: deps.server,` at [`:156`](../../../src/tools/define.ts#L156) and
+  [`:189`](../../../src/tools/define.ts#L189).
+- **Keep** `ToolDeps.server` at [`:87`](../../../src/tools/define.ts#L87), the
+  `deps.server.server.getClientCapabilities()` read at
+  [`:175`](../../../src/tools/define.ts#L175), and
+  `deps.server.registerTool(...)` at
+  [`:540`](../../../src/tools/define.ts#L540).
+- `toToolCtx`'s `deps` parameter is
+  `Pick<ToolDeps, 'pathGuard' | 'pageStore' | 'resourceStore' | 'server'>` at
+  [`:147`](../../../src/tools/define.ts#L147) — `'server'` must **stay** in that
+  Pick: line 175 still reads it.
+- If the `McpServer` type import becomes unused in this file, remove it;
+  `eslint` will say so.
+
+**Verify**: `node scripts/tasks.mjs --quick` → exit 0
+
+### 2. Delete `singleOrBatchPathsInput`'s unpassed `maxBatch`
+
+In [`src/core/schema.ts`](../../../src/core/schema.ts): drop `maxBatch?: number;`
+from the options object at [`:281`](../../../src/core/schema.ts#L281) and the
+`const maxBatch = opts.maxBatch ?? DEFAULT_MAX_BATCH;` line at
+[`:283`](../../../src/core/schema.ts#L283); use `DEFAULT_MAX_BATCH`
+([`:274`](../../../src/core/schema.ts#L272)) directly in the `.max(...)` call and
+in the description template string.
+
+Both callers already pass only `{ extra }` — no call site changes.
+
+**Verify**: `node scripts/tasks.mjs --quick` → exit 0
+
+### 3. Delete the never-passed `annotations` param on both link builders
+
+In [`src/core/file-uri.ts`](../../../src/core/file-uri.ts): remove the
+`annotations` parameter from `buildFileResourceLinkFor`
+([`:42-50`](../../../src/core/file-uri.ts#L42-L50)) and `buildFileResourceLink`
+([`:52-65`](../../../src/core/file-uri.ts#L52-L65)), inlining
+`{ audience: ['user', 'assistant'] }` into the returned block, and drop the
+argument from the internal call at
+[`:63`](../../../src/core/file-uri.ts#L63).
+
+Target shape:
+
+```ts
+export function buildFileResourceLinkFor(
+  uri: string,
+  name: string,
+  mimeType: string,
+  size: number,
+): ContentBlock {
+  return {
+    type: 'resource_link',
+    uri,
+    name,
+    mimeType,
+    size,
+    annotations: { audience: ['user', 'assistant'] },
+  };
+}
+```
+
+No call-site changes — all six already omit the argument.
+
+**Verify**: `node scripts/tasks.mjs --quick` → exit 0
+
+### 4. Inline `createReadRangeFields` into `read.ts`
+
+Delete `ReadRangeDescriptions`
+([`schema.ts:182-187`](../../../src/core/schema.ts#L182-L187)),
+`createReadRangeFields`
+([`schema.ts:189-203`](../../../src/core/schema.ts#L189-L203)), and the
+now-answered TODO above them at
+[`schema.ts:179-181`](../../../src/core/schema.ts#L179-L181).
+
+In [`src/tools/read.ts`](../../../src/tools/read.ts), replace the
+`createReadRangeFields({...})` call at
+[`:41-47`](../../../src/tools/read.ts#L41-L47) with the four literals, keeping
+the same bounds and messages:
+
+```ts
+const rangeField = (description: string) =>
+  z
+    .int32()
+    .min(1, { message: 'Min: 1' })
+    .max(100000, { message: 'Max: 100,000' })
+    .optional()
+    .describe(description);
+
+const readRangeFields = {
+  head: rangeField('Return first N lines'),
+  tail: rangeField('Return last N lines'),
+  startLine: rangeField('Start line (1-indexed)'),
+  endLine: rangeField('End line (1-indexed)'),
+};
+```
+
+Drop `createReadRangeFields` from `read.ts`'s import of `../core/schema.js`;
+keep `validateReadRange`.
+
+> The published input schema must not change. `tools.test.ts`'s
+> TOOL-SURFACE-001/002 assert on the emitted schema — if they fail, a bound or a
+> description drifted.
+
+**Verify**: `node scripts/tasks.mjs test` → `pass 276 fail 0`
+
+### 5. Delete the test-only `ALL_REGISTERED_TOOL_NAMES` export
+
+Delete [`index.ts:41`](../../../src/tools/index.ts#L41). In each of the six test
+files, drop it from the `../src/tools/index.js` import and compute it locally
+beside the existing `ALL_TOOLS` usage:
+
+```ts
+const ALL_REGISTERED_TOOL_NAMES = ALL_TOOLS.map((t) => t.name);
+```
+
+Files and their references:
+`http-server.test.ts:11,199`; `http-transport.test.ts:6,37`;
+`inspector-stdio.test.ts:6,81,82`; `smoke.test.ts:6,36,39`;
+`stdio.test.ts:13,59`; `tools.test.ts:22,231`.
+
+Each file must import `ALL_TOOLS` from `../src/tools/index.js`. Only
+`tools.test.ts` ([`:23`](../../../__tests__/tools.test.ts#L23)) has it today —
+the other five add it to the same import statement they are already editing.
+Assertions stay byte-identical.
+
+**Verify**: `node scripts/tasks.mjs test` → `pass 276 fail 0`
+
+### 6. Delete the zero-caller `Problem.ioError`
+
+Delete [`errors.ts:57`](../../../src/core/errors.ts#L57). `ErrorCode.IO_ERROR`
+stays — it is still produced by `ERRNO_MAP` classification and read by
+`fromUnknown`'s `shouldOverride` check at
+[`errors.ts:60-61`](../../../src/core/errors.ts#L60-L61).
+
+**Verify**: `node scripts/tasks.mjs --quick` → exit 0
+
+### 7. Collapse the four error-shape declarations onto `Problem`
+
+Three edits, one commit — the type must land everywhere at once or the build
+breaks between them.
+
+1. [`src/core/errors.ts`](../../../src/core/errors.ts): delete the
+   `PerFileError` interface ([`:20-25`](../../../src/core/errors.ts#L20-L25)) and
+   collapse `toPerFileError`'s body
+   ([`:76-90`](../../../src/core/errors.ts#L76-L90)) to:
+
+   ```ts
+     toPerFileError(
+       error: unknown,
+       defaultCode: ErrorCode = ErrorCode.UNKNOWN,
+       path?: string,
+     ): Problem {
+       return Problem.fromUnknown(error, defaultCode, path);
+     },
+   ```
+
+2. [`src/tools/batch.ts`](../../../src/tools/batch.ts): delete the `PerPathError`
+   interface ([`:10-15`](../../../src/tools/batch.ts#L10-L15)) and change
+   `PerPathResult<T>` ([`:29`](../../../src/tools/batch.ts#L29)) to use
+   `Problem`, which is already imported at
+   [`:4`](../../../src/tools/batch.ts#L4).
+
+3. [`src/tools/delete-file.ts`](../../../src/tools/delete-file.ts): type
+   `DeleteFailure.error` as `Problem`
+   ([`:76-84`](../../../src/tools/delete-file.ts#L76-L84)) — `Problem` is already
+   imported at [`:15`](../../../src/tools/delete-file.ts#L15). `toDeleteFailure`
+   already returns exactly that shape via `Problem.toPerFileError`.
+
+`code` narrows from `string` to `ErrorCode` on `DeleteFailure`. The wire schema
+`PerFileErrorSchema` keeps `code: z.string()`
+([`schema.ts:166-171`](../../../src/core/schema.ts#L166-L171)) — do not change
+it; `ErrorCode` is a string union and validates unchanged.
+
+**Verify**: `node scripts/tasks.mjs test` → `pass 276 fail 0`
+
+### 8. Extract `computeDiffStats` and `unifiedPatch` into `fmt.ts`
+
+Add both to [`src/core/fmt.ts`](../../../src/core/fmt.ts), importing
+`createTwoFilesPatch` and `diffLines` from `diff`:
+
+```ts
+export function computeDiffStats(
+  original: string,
+  modified: string,
+): { linesAdded: number; linesRemoved: number } {
+  // diffLines returns the change list synchronously on diff v9.
+  let linesAdded = 0;
+  let linesRemoved = 0;
+  for (const part of diffLines(original, modified)) {
+    if (part.added) linesAdded += part.count;
+    else if (part.removed) linesRemoved += part.count;
+  }
+  return { linesAdded, linesRemoved };
+}
+
+// createTwoFilesPatch returns the unified diff string synchronously on diff v9
+// (the { callback } option fires via setTimeout and returns undefined).
+export function unifiedPatch(label: string, original: string, modified: string): string {
+  return createTwoFilesPatch(label, label, original, modified, 'Original', 'Modified');
+}
+```
+
+Repoint the four sites:
+
+- [`edit.ts:179-191`](../../../src/tools/edit.ts#L179-L191): delete the local
+  `computeDiffStats`; import it from `../core/fmt.js`. The call at
+  [`edit.ts:321`](../../../src/tools/edit.ts#L321) is unchanged.
+- [`edit.ts:425-434`](../../../src/tools/edit.ts#L425-L434):
+  `editResult.diff = unifiedPatch(basename(validPath), content, editResult.content);`
+- [`diff.ts:61-67`](../../../src/tools/diff.ts#L61-L67): replace the inline loop
+  with `const { linesAdded, linesRemoved } = computeDiffStats(contentA, contentB);`
+  — note the downstream code mutates neither, so `const` destructuring is safe.
+- [`replace-in-files.ts:400-412`](../../../src/tools/replace-in-files.ts#L400-L412):
+  `const patch = unifiedPatch(header, params.originalContent, params.updatedContent);`
+
+Drop the now-unused `diffLines` / `createTwoFilesPatch` imports from any of the
+three tool files where they no longer appear. `diff.ts` keeps
+`createTwoFilesPatch` — its call at
+[`diff.ts:51-59`](../../../src/tools/diff.ts#L51-L59) passes different headers
+and is not folded.
+
+**Verify**: `node scripts/tasks.mjs test` → `pass 276 fail 0`
+
+### 9. Extract the post-write metadata block into `file-uri.ts`
+
+Add to [`src/core/file-uri.ts`](../../../src/core/file-uri.ts):
+
+```ts
+export interface WrittenFileMeta {
+  bytesWritten: number;
+  lineCount: number;
+  mimeType: string;
+  kind: FileKind;
+  /** Undefined when nothing was written: there is no updated content to point at. */
+  resourceUri: string | undefined;
+  resourceLink: ContentBlock | undefined;
+}
+
+export function buildWrittenFileMeta(
+  validPath: string,
+  content: string,
+  opts: { written?: boolean; resourceStore?: ResourceStore | undefined },
+): WrittenFileMeta {
+  const bytesWritten = Buffer.byteLength(content, 'utf-8');
+  const mimeInfo = detectMimeFromContent(validPath, content);
+  // Omitted rather than empty-stringed when nothing matched: `""` satisfied the
+  // schema's `string` and then failed every resources/read a client tried it on.
+  const written = opts.written ?? true;
+  return {
+    bytesWritten,
+    lineCount: countLines(content),
+    mimeType: mimeInfo.mimeType,
+    kind: mimeInfo.kind,
+    resourceUri: written ? buildFileResourceUri(validPath) : undefined,
+    resourceLink:
+      written && opts.resourceStore
+        ? buildFileResourceLink(validPath, mimeInfo.mimeType, bytesWritten)
+        : undefined,
+  };
+}
+```
+
+`file-uri.ts` gains imports of `detectMimeFromContent` (`./mime.js`),
+`countLines` (`./read.js`), `FileKind` (`./schema.js`), and `ResourceStore`
+(`./store.js`).
+
+> If any of those introduces an import cycle that `tsc` or `eslint` rejects, that
+> is a [STOP](#stop) condition — report it rather than moving the helper
+> elsewhere.
+
+Repoint the three sites, each keeping its own output shape:
+
+- [`patch.ts:43-71`](../../../src/tools/patch.ts#L43-L71): delete `PatchMeta` and
+  `buildPatchMeta`; call
+  `buildWrittenFileMeta(validPath, patched, { resourceStore })` and map
+  `bytesWritten → size`, `resourceLink → link` at the use site. `resourceUri` is
+  non-optional in `PatchOutputSchema`
+  ([`patch.ts:36`](../../../src/tools/patch.ts#L36)) — with `written` defaulting
+  to true it is always a string here, so assert or narrow at the use site rather
+  than widening the schema.
+- [`edit.ts:334-368`](../../../src/tools/edit.ts#L334-L368): delete
+  `EditFileMetadata` and `buildEditFileMetadata`; call
+  `buildWrittenFileMeta(validPath, content, { written: appliedEdits > 0, resourceStore })`.
+- [`create.ts:98-121`](../../../src/tools/create.ts#L98-L121): replace the inline
+  five steps with one call, `{ resourceStore: ctx.resourceStore }`.
+
+> The `appliedEdits > 0` gate must survive exactly: an edit that matched nothing
+> emits neither `resourceUri` nor a link.
+
+**Verify**: `node scripts/tasks.mjs test` → `pass 276 fail 0`
+
+### 10. Delete `getFileType`, repoint to `resolveEntryType`
+
+Delete [`fs.ts:123-128`](../../../src/core/fs.ts#L123-L128). Repoint the three
+callers to `resolveEntryType` from `../core/glob.js`:
+
+- [`stat.ts:70`](../../../src/tools/stat.ts#L70) —
+  `type: isSymlink ? 'symlink' : resolveEntryType(stats),`
+- [`delete-file.ts:181`](../../../src/tools/delete-file.ts#L181) —
+  `const itemType = resolveEntryType(firstStats.stats);`
+- [`delete-file.ts:230`](../../../src/tools/delete-file.ts#L230) —
+  `const currentItemType = resolveEntryType(currentStats.stats);`
+
+Update both files' imports: drop `getFileType` from `../core/fs.js`, add
+`resolveEntryType` from `../core/glob.js`. `delete-file.ts` keeps its
+`import type { FileType, GuardedFileSystem }` — `ItemType = FileType` at
+[`delete-file.ts:116`](../../../src/tools/delete-file.ts#L116) still resolves, as
+`FileType` and `EntryType` are the same type. If `Stats` becomes an unused import
+in `fs.ts`, remove it.
+
+**Verify**: `node scripts/tasks.mjs test` → `pass 276 fail 0`
+
+### 11. Reduce `GuardedFileSystem.open` to its one reachable form
+
+Replace [`fs.ts:281-296`](../../../src/core/fs.ts#L281-L296) with:
+
+```ts
+  async open(filePath: string): Promise<FileHandle> {
+    const validPath = await this.pathGuard.validateExistingPath(filePath);
+    return fsOpen(validPath, 'r');
+  }
+```
+
+Delete the three-line comment above it — it described the branch that is gone.
+Update the one caller,
+[`replace-in-files.ts:375`](../../../src/tools/replace-in-files.ts#L375), to
+`await ctx.fs.open(validPath)`. If `fsConstants` is now unused in `fs.ts`, remove
+its import.
+
+**Verify**: `node scripts/tasks.mjs test` → `pass 276 fail 0`
+
+### 12. Replace the hand-rolled basename, and cover the branch
+
+In [`src/core/search.ts`](../../../src/core/search.ts): add
+`import { basename } from 'node:path';` and replace the comparator at
+[`:313-318`](../../../src/core/search.ts#L313-L318) with:
+
+```ts
+  if (options.sortBy === 'name') {
+    results.sort((a, b) => basename(a.path).localeCompare(basename(b.path)));
+  } else {
+```
+
+This branch has no coverage today, so add one case to
+[`__tests__/core-fs.test.ts`](../../../__tests__/core-fs.test.ts), directly after
+TC-FUNC-039 ([`:193-209`](../../../__tests__/core-fs.test.ts#L193-L209)), in the
+same `describe('Search & Glob (TC-FUNC-039–046)')` block. It must fail if the
+comparator reverts to path-order:
+
+```ts
+    it("TC-FUNC-039b: searchFiles sortBy 'name' orders by basename, not full path", async () => {
+      await writeTestFile(tmpDir, 'sort_dir/zzz/alpha.ts', '// a');
+      await writeTestFile(tmpDir, 'sort_dir/aaa/omega.ts', '// o');
+
+      const sortDir = join(tmpDir, 'sort_dir');
+      const byName = await searchFiles(sortDir, '**/*.ts', [], { sortBy: 'name' }, ctx.pathGuard);
+      assert.deepStrictEqual(
+        byName.results.map((r) => basename(r.path)),
+        ['alpha.ts', 'omega.ts'],
+      );
+
+      const byPath = await searchFiles(sortDir, '**/*.ts', [], {}, ctx.pathGuard);
+      assert.deepStrictEqual(
+        byPath.results.map((r) => basename(r.path)),
+        ['omega.ts', 'alpha.ts'],
+      );
+    });
+```
+
+`basename` must be added to the `node:path` import at
+[`core-fs.test.ts:3`](../../../__tests__/core-fs.test.ts#L3) (currently
+`dirname, join`).
+
+> `aaa/omega.ts` sorts before `zzz/alpha.ts` by path and after it by basename —
+> that opposition is what makes the test falsifying. If `byPath` comes back in
+> the same order as `byName`, the fixture is wrong, not the code.
+
+**Verify**: `node scripts/tasks.mjs test` → `pass 277 fail 0`
+
+### 13. Fold `runOverPairs` into `move.ts` as a non-generic driver
+
+The largest diff; it lands last so every earlier step is already green.
+
+In [`src/tools/move.ts`](../../../src/tools/move.ts), add a module-local
+`runTransfers` over the concrete types — no type parameters:
+
+```ts
+type TransferPlanResult =
+  | { status: 'fail'; failure: MoveFailureItem }
+  | { status: 'noop' }
+  | { status: 'plan'; plan: TransferPlan };
+
+type TransferExecResult = { readonly skipped: string } | { readonly value: MoveItemResult };
+
+async function runTransfers(
+  items: readonly z.infer<typeof MoveItemSchema>[],
+  ctx: ToolCtx,
+  op: PairOp,
+  plan: (item: z.infer<typeof MoveItemSchema>) => Promise<TransferPlanResult>,
+  execute: (plan: TransferPlan, pendingSorted: readonly string[]) => Promise<TransferExecResult>,
+): Promise<
+  { results: MoveItemResult[]; skipped: string[]; failures: MoveFailureItem[] } | InputRequiredResult
+> {
+  // body of runOverPairs, verbatim, with the type parameters resolved
+}
+```
+
+Move the body of
+[`batch.ts:187-302`](../../../src/tools/batch.ts#L187-L302) across **verbatim**,
+including every comment: the fail-closed plan-error rethrow, the
+duplicate-destination fail-closed loop and its explanation, the `pendingSorted` /
+`pendingRoundTrip` R9 block with its `confirm_${i}` indexing, the progress
+`tick`, and the `rethrowIfAborted` fold over `execErrors`. `verb` comes from the
+existing `VERB` map at [`move.ts:69`](../../../src/tools/move.ts#L69) — use
+`VERB[op]` and drop the local `const verb = opts.op === 'copy' ? …` line.
+
+Move `pairFailure` ([`batch.ts:161-170`](../../../src/tools/batch.ts#L161-L170))
+into `move.ts` too — it is the driver's helper and `move.ts` is its only other
+user (`planTransfer` at
+[`move.ts:117`](../../../src/tools/move.ts#L117) and
+[`:138`](../../../src/tools/move.ts#L138)). Its return type becomes
+`MoveFailureItem`.
+
+Then in [`src/tools/batch.ts`](../../../src/tools/batch.ts) delete: `PairPlan`
+([`:115-120`](../../../src/tools/batch.ts#L115-L120)), `PairPlanResult`
+([`:122-125`](../../../src/tools/batch.ts#L122-L125)), `PairExecResult`
+([`:128`](../../../src/tools/batch.ts#L128)), `PairBatchOutcome`
+([`:130-134`](../../../src/tools/batch.ts#L130-L134)), `pairFailure`,
+`RunOverPairsOptions` ([`:172-179`](../../../src/tools/batch.ts#L172-L179)),
+`runOverPairs` with its doc comment
+([`:181-302`](../../../src/tools/batch.ts#L181-L302)), and `PairFailureItem`
+([`:17-27`](../../../src/tools/batch.ts#L17-L27)).
+
+`PairFailureItem` goes with them: all five of its occurrences are in `batch.ts`,
+four of them inside the code this step deletes or moves, and the fifth is
+`pairFailure`'s return annotation, which moves to `move.ts` typed as
+`MoveFailureItem`. `move.ts` never imported it. Leaving it behind makes it an
+exported type with zero references, which `knip` reports and `check:static` fails
+on — see finding 1 in
+[`overeng-residue.plan-hunt.md`](overeng-residue.plan-hunt.md).
+
+Keep in `batch.ts`: `runOverPaths`; `isTotalFailure`; `normalizeBatchItems`;
+`BatchResult`; `PerPathResult`. Adjust `isTotalFailure`'s doc comment
+([`:146`](../../../src/tools/batch.ts#L146)) — it names `runOverPairs`; say
+"move's pair outcome" instead.
+
+`move.ts`'s import line
+([`:22-23`](../../../src/tools/move.ts#L22-L23)) becomes
+`import { isTotalFailure } from './batch.js';` — one value import, no type
+import. `MoveFailureItem` ([`move.ts:51`](../../../src/tools/move.ts#L51))
+covers every failure-shape use inside `move.ts`. `batch.ts` may no longer need
+`InputRequiredResult`, `pendingRoundTrip`, `choiceInput`,
+`IS_CASE_INSENSITIVE_FS`, or `rethrowIfAborted` — drop whichever `eslint`
+reports unused, and add them to `move.ts`.
+
+Behavior that must not change, all test-pinned: an all-failed batch still reports
+`isError` via `isTotalFailure`
+([`move.ts:394`](../../../src/tools/move.ts#L394)); a duplicate destination still
+fails closed with the same message; a pending overwrite still round-trips as
+`confirm_${i}` over the **sorted** destination list; a self-move is still
+silently skipped.
+
+**Verify**: `node scripts/tasks.mjs` → exit 0, `pass 277 fail 0`
+
+## Done
+
+All must hold:
+
+- [ ] `node scripts/tasks.mjs --quick` exits 0 — build, both type-checks, eslint,
+      prettier, and knip clean
+- [ ] `node scripts/tasks.mjs test` exits 0 with `pass 277 fail 0` (276 baseline +
+      TC-FUNC-039b)
+- [ ] `git status` shows no modified file outside the [Scope](#scope) in-scope
+      list
+- [ ] `git grep -n "PerFileError\b" src/` returns nothing (the schema's
+      `PerFileErrorSchema` is a different identifier and may still match — check
+      the hits are only that)
+- [ ] `git grep -n "runOverPairs\|PairBatchOutcome\|PairPlanResult\|PairExecResult\|PairFailureItem\|getFileType\|createReadRangeFields\|ALL_REGISTERED_TOOL_NAMES\|ioError" src/`
+      returns nothing
+- [ ] `git grep -c "createTwoFilesPatch" src/` shows it only in
+      `src/core/fmt.ts` and `src/tools/diff.ts`
+
+## STOP
+
+Stop and report if:
+
+- The code at a [Current state](#current-state) location does not match its
+  excerpt — the drift check flagged a file and this plan was written against
+  `6cedcca9`.
+- A step's verification fails twice after one fix attempt. A second failure means
+  the step's assumption is wrong, not its implementation.
+- Step 9's helper introduces an import cycle (`file-uri.ts` → `mime.ts` /
+  `read.ts` / `schema.ts` / `store.ts`) that `tsc` or `eslint` rejects. Do not
+  relocate the helper on your own judgment — report the cycle.
+- Step 13 changes any observable move/copy behavior: a different failure message,
+  a different `confirm_*` key, an `isError` that flips, or a self-move that stops
+  being silent. The fold is verbatim or it is wrong.
+- `knip` reports an export as unused that this plan does not name. The prior
+  effort's rule applies: STOP and report rather than widening the cut.
+- A cut appears to require a file on the out-of-scope list — in particular
+  `cli.ts`, `store.ts`, `page-store.ts`, or `path.ts`.
+- The published tool schemas change: `tools.test.ts`'s TOOL-SURFACE-001 or
+  TOOL-SURFACE-002 failing means a description or bound drifted, which is a wire
+  change, not a cleanup.
+
+## Notes
+
+**For the reviewer, in descending order of suspicion:**
+
+- **Step 13** is the only step big enough to hide a behavior change. Read it as a
+  move, not a rewrite: the diff should show the same statements in the same order
+  with `TPlan` → `TransferPlan` and `TResult` → `MoveItemResult`. Anything else
+  in that hunk deserves a question.
+- **Step 9** trades three explicit blocks for one helper plus an options object.
+  The `written` flag is the `appliedEdits > 0` gate in disguise; if the parameter
+  reads worse at the three call sites than the duplication did, say so — the cut
+  is worth reverting, and only that one.
+- **Step 5** is the weakest cut by line count: it deletes one line from `src/` and
+  adds one to each of six test files. Its value is that `src/tools/index.ts` stops
+  exporting for tests only; if the churn is judged not worth it, this step is
+  independently droppable.
+
+**Deliberately not done:**
+
+- The `--safe` CLI alias stays. It is documented public surface; removing it is a
+  breaking change that belongs to a release, not a cleanup.
+- `delete-file.ts` is not routed through the pair driver, and `ResourceStore` is
+  not merged with `PageSnapshotStore` — both adversarially refuted; see
+  [Scope](#scope) for why.
+
+**Rollback**: every step is a pure source edit on a branch, no migration and no
+data. `git checkout -- src/ __tests__/` undoes uncommitted work; `git revert`
+the commit undoes a landed step.

--- a/docs/plan/2026-09-07-overeng-residue/overeng-residue.run.md
+++ b/docs/plan/2026-09-07-overeng-residue/overeng-residue.run.md
@@ -1,0 +1,56 @@
+# Run: cut the 16 verified over-engineering residues left by the 2026-09-07 audit
+
+Executing [`overeng-residue.plan.md`](overeng-residue.plan.md), started
+2026-09-07 at `6cedcca9`, on branch `refactor/overeng-residue`.
+
+Drift check `git diff --stat 6cedcca9..HEAD -- src/ __tests__/` → empty, no
+files flagged. Baseline `node scripts/tasks.mjs test` → `pass 276 fail 0`.
+
+- **1** 2026-09-07 — done. Deleted `ToolCtx.sessionId` + `ToolCtx.server` and their three assignments in `define.ts`; `ToolDeps.server` and the `Pick` entry kept. `node scripts/tasks.mjs --quick` → exit 0.
+- **2** 2026-09-07 — done. Deleted `singleOrBatchPathsInput`'s `maxBatch` option and the `?? DEFAULT_MAX_BATCH` fallback; constant used directly. `node scripts/tasks.mjs --quick` → exit 0.
+- **3** 2026-09-07 — done. Deleted the never-passed `annotations` param from both link builders; `{ audience: ['user', 'assistant'] }` inlined. `node scripts/tasks.mjs --quick` → exit 0.
+- **4** 2026-09-07 — done. Inlined `createReadRangeFields` into `read.ts` as a local `rangeField` helper; factory + `ReadRangeDescriptions` + its TODO deleted from `schema.ts`. `node scripts/tasks.mjs test` → `pass 276 fail 0`; `--quick` → exit 0.
+- **5** 2026-09-07 — done. Deleted `ALL_REGISTERED_TOOL_NAMES` from `src/tools/index.ts`; six test files now compute it from `ALL_TOOLS` locally. Prettier flagged `tools.test.ts`, fixed by `node scripts/tasks.mjs fix`. `test` → `pass 276 fail 0`; `--quick` → exit 0.
+- **6** 2026-09-07 — done. Deleted the zero-caller `Problem.ioError`; `ErrorCode.IO_ERROR` kept. `node scripts/tasks.mjs --quick` → exit 0.
+- **7** 2026-09-07 — done. Collapsed all four declarations of `{code, message, path?, suggestion?}` onto `Problem`: deleted `PerFileError` and `toPerFileError`'s rebuild, `batch.ts`'s `PerPathError`, and `delete-file.ts`'s inline `DeleteFailure.error`. `test` → `pass 276 fail 0`; `--quick` → exit 0.
+- **8** 2026-09-07 — done. Extracted `computeDiffStats` + `unifiedPatch` into `src/core/fmt.ts`; repointed `edit.ts` (both sites), `diff.ts` (stats loop), `replace-in-files.ts` (patch call). `diff.ts` keeps its own `createTwoFilesPatch` call. `test` → `pass 276 fail 0`; `--quick` → exit 0.
+- **9** 2026-09-07 — done, with one deviation. Extracted `buildWrittenFileMeta` into `src/core/file-uri.ts`; repointed `patch.ts`, `edit.ts`, `create.ts`. **Deviation**: the plan put the `appliedEdits > 0` gate inside the helper as a `written` option; the helper instead has no mode flag and `edit.ts`'s `buildEditFileMetadata` applies the gate at its own site (`written ? meta.resourceUri : undefined`, same for the link). The gate is preserved exactly and only edit.ts has one — no caller-visible difference, one fewer parameter. No import cycle: `mime.ts`/`read.ts`/`schema.ts`/`store.ts` do not import `file-uri.ts`. `test` → `pass 276 fail 0`; `--quick` → exit 0.
+- **10** 2026-09-07 — done. Deleted `getFileType` from `fs.ts`; `stat.ts` and both `delete-file.ts` sites now call `resolveEntryType` from `core/glob.js`. `test` → `pass 276 fail 0`; `--quick` → exit 0.
+- **11** 2026-09-07 — done. `GuardedFileSystem.open` reduced to `open(filePath)` with a fixed `'r'`; the write-guard branch, the flags/mode params, and the now-dead `constants as fsConstants` import removed; `replace-in-files.ts:375` updated. `test` → `pass 276 fail 0`; `--quick` → exit 0.
+- **12** 2026-09-07 — done. `searchFiles` sortBy 'name' now uses `basename()` from `node:path`; added TC-FUNC-039b to `core-fs.test.ts`. `test` → `pass 277 fail 0`; `--quick` → exit 0. **Note**: the new test pins the branch's behavior (basename order vs path order), which was previously uncovered. It does not distinguish the old comparator from the new one — the two differ only for a literal `\` inside a filename, which is not representable on this Windows host.
+- **13** 2026-09-07 — done. Folded the pair driver into `move.ts` as non-generic `runTransfers` over `TransferPlan`/`MoveItemResult`; `pairFailure` moved with it and now returns `MoveFailureItem`. Deleted from `batch.ts`: `PairFailureItem`, `PairPlan`, `PairPlanResult`, `PairExecResult`, `PairBatchOutcome`, `RunOverPairsOptions`, `pairFailure`, `runOverPairs`, and the imports only they used (`InputRequiredResult`, `choiceInput`, `pendingRoundTrip`, `IS_CASE_INSENSITIVE_FS`, `rethrowIfAborted`); `isTotalFailure`'s doc comment reworded. Body moved verbatim — same fail-closed plan-error rethrow, duplicate-destination guard and message, `confirm_${i}` indexing over the sorted pending list, progress tick, and abort rethrow. `node scripts/tasks.mjs` → exit 0, `pass 277 fail 0`.
+
+## Done
+
+- [x] `node scripts/tasks.mjs --quick` → exit 0 (build, both type-checks, eslint, prettier, knip clean).
+- [x] `node scripts/tasks.mjs test` → `tests 277 · suites 61 · pass 277 · fail 0`.
+- [x] `git status` → 25 modified files, all in the plan's in-scope list; the only untracked path is this effort's own `docs/plan/2026-09-07-overeng-residue/`.
+- [x] `git grep -n "PerFileError" src/` → remaining hits are `PerFileErrorSchema` (the wire schema, a different identifier) and `Problem.toPerFileError` (kept). No `PerFileError` interface.
+- [x] `git grep -n "runOverPairs\|PairBatchOutcome\|PairPlanResult\|PairExecResult\|PairFailureItem\|getFileType\|createReadRangeFields\|ALL_REGISTERED_TOOL_NAMES\|ioError" src/` → empty, after fixing one out-of-plan hit (below).
+- [x] `git grep -c "createTwoFilesPatch" src/` → `src/core/fmt.ts:3`, `src/tools/diff.ts:3`. Nothing else.
+
+## Deviations
+
+1. **Step 9** — the `appliedEdits > 0` gate stayed at `edit.ts`'s call site instead of becoming a `written` option on the shared helper. The helper has no mode flag; `buildEditFileMetadata` blanks `resourceUri`/`resourceLink` itself. Gate preserved exactly, one fewer parameter, no caller-visible difference.
+2. **Done checklist, hit outside the plan** — `src/core/primitives.ts:8` carried a doc comment naming `getFileType`. Step 10 deleted the function but the plan never listed this file. Fixed as a one-word comment edit (the sentence now names only `resolveEntryType`); no code touched. Reported rather than silently widened.
+3. **Step 12 test scope** — TC-FUNC-039b pins the `sortBy: 'name'` branch's behavior (previously zero coverage) but cannot distinguish the old comparator from the new one: they differ only for a literal `\` inside a filename, which Windows cannot create.
+
+## Post-review pass — 2026-09-07
+
+`bug-hunt` returned zero findings (see [`overeng-residue.hunt.md`](overeng-residue.hunt.md)).
+`qc` returned REQUEST_CHANGES with four shape regressions and six missed
+code-judo moves — no behavior objection. All ten applied on the same branch.
+
+- **R1** `src/core/file-uri.ts:9-11` — module header restated; it claimed to own only the URI scheme while the file had grown the post-write metadata block.
+- **R2** `computeDiffStats` + `unifiedPatch` moved out of `fmt.ts` into a new `src/core/diff.ts`; `fmt.ts` formats terminal output and no longer drags the `diff` package into `cli.ts`'s import chain. Repointed `edit.ts`, `diff.ts`, `replace-in-files.ts`.
+- **R3** `resolveEntryType` + `DirentLike` moved from `core/glob.ts` to `core/primitives.ts`, which already owns `ENTRY_TYPES`/`EntryType`. `stat.ts`, `delete-file.ts` and `list.ts` now import the concept from its owner instead of routing through the glob module; no re-export left behind.
+- **R4** `ALL_REGISTERED_TOOL_NAMES` moved to `__tests__/helpers.ts` as one export. Step 5 had traded a single production export for six verbatim copies; `src/tools/index.ts` still stops exporting for tests, which was the point.
+- **J5** `runTransfers` dropped its `plan`/`execute` callback parameters — one call site, both wrappers closing over only `op`/`ctx`/`overwrite`. Now `runTransfers(items, ctx, op, overwrite)` calling `planTransfer`/`executeTransfer` directly.
+- **J6** `Problem.toPerFileError` deleted — step 7 had collapsed it to a pass-through over `fromUnknown`. Five call sites (`batch.ts`, `delete-file.ts` ×3, `move.ts`) repointed; all already passed an explicit `defaultCode`, and `replace-in-files.ts` already called `fromUnknown` directly.
+- **J7** `singleOrBatchPathsInput` takes `extra` directly instead of a one-field options bag (`{ extra: {} }` had outlived `maxBatch`).
+- **J8** dead `signal` parameter dropped from `maybeAppendPatchDiff` and its call site.
+- **J9** `WrittenFileMeta.bytesWritten` renamed to `size` — all four consumers renamed it at the use site. `EditFileMetadata` collapsed to `Omit<WrittenFileMeta, 'resourceUri'> & { resourceUri: string | undefined }`, removing the fifth hand-declaration of the shape.
+- **J10** `isTotalFailure` narrowed to `{ total, failed }`; the pair-shape branch and its `'total' in shape` discriminant are gone, inlined at `move.ts`'s one call site. That was the last piece of the pair driver still living in `batch.ts`.
+
+`node scripts/tasks.mjs` → exit 0, `tests 277 · suites 61 · pass 277 · fail 0`.
+Net across the branch: 28 files, 337 insertions, 502 deletions (-165 lines).

--- a/src/core/diff.ts
+++ b/src/core/diff.ts
@@ -1,0 +1,24 @@
+import { createTwoFilesPatch, diffLines } from 'diff';
+
+// Unified-diff computation over two text buffers. Kept out of `fmt.ts`, which
+// formats terminal output and has no business pulling in the `diff` package.
+
+export function computeDiffStats(
+  original: string,
+  modified: string,
+): { linesAdded: number; linesRemoved: number } {
+  // diffLines returns the change list synchronously on diff v9.
+  let linesAdded = 0;
+  let linesRemoved = 0;
+  for (const part of diffLines(original, modified)) {
+    if (part.added) linesAdded += part.count;
+    else if (part.removed) linesRemoved += part.count;
+  }
+  return { linesAdded, linesRemoved };
+}
+
+// createTwoFilesPatch returns the unified diff string synchronously on diff v9
+// (the { callback } option fires via setTimeout and returns undefined).
+export function unifiedPatch(label: string, original: string, modified: string): string {
+  return createTwoFilesPatch(label, label, original, modified, 'Original', 'Modified');
+}

--- a/src/core/errors.ts
+++ b/src/core/errors.ts
@@ -18,13 +18,6 @@ export const ErrorCode = {
 
 export type ErrorCode = (typeof ErrorCode)[keyof typeof ErrorCode];
 
-interface PerFileError {
-  readonly code: ErrorCode;
-  readonly message: string;
-  readonly path?: string;
-  readonly suggestion?: string;
-}
-
 export interface Problem {
   readonly code: ErrorCode;
   readonly message: string;
@@ -54,7 +47,6 @@ export const Problem = {
   timeout: (msg: string, o?: ProblemFactoryOptions): Problem => build(ErrorCode.TIMEOUT, msg, o),
   cancelled: (msg: string, o?: ProblemFactoryOptions): Problem =>
     build(ErrorCode.CANCELLED, msg, o),
-  ioError: (msg: string, o?: ProblemFactoryOptions): Problem => build(ErrorCode.IO_ERROR, msg, o),
   unknown: (msg: string, o?: ProblemFactoryOptions): Problem => build(ErrorCode.UNKNOWN, msg, o),
   fromUnknown(error: unknown, defaultCode: ErrorCode, path?: string): Problem {
     const problem = classify(error);
@@ -74,19 +66,6 @@ export const Problem = {
   toText(error: unknown, defaultCode: ErrorCode): { code: ErrorCode; text: string } {
     const resolved = Problem.fromUnknown(error, defaultCode);
     return { code: resolved.code, text: formatDetailedError(resolved) };
-  },
-  toPerFileError(
-    error: unknown,
-    defaultCode: ErrorCode = ErrorCode.UNKNOWN,
-    path?: string,
-  ): PerFileError {
-    const problem = Problem.fromUnknown(error, defaultCode, path);
-    return {
-      code: problem.code,
-      message: problem.message,
-      ...(problem.path !== undefined ? { path: problem.path } : {}),
-      ...(problem.suggestion !== undefined ? { suggestion: problem.suggestion } : {}),
-    };
   },
 } as const;
 

--- a/src/core/file-uri.ts
+++ b/src/core/file-uri.ts
@@ -2,8 +2,14 @@ import type { ContentBlock } from '@modelcontextprotocol/server';
 
 import { basename } from 'node:path';
 
-// Single owner of the `filesystem-mcp://file/` URI scheme: the template string,
-// the path→URI encoder, and the URI→path decoder.
+import { detectMimeFromContent } from './mime.js';
+import { countLines } from './read.js';
+import type { FileKind } from './schema.js';
+import type { ResourceStore } from './store.js';
+
+// Single owner of the `filesystem-mcp://file/` URI scheme — the template string,
+// the path→URI encoder, the URI→path decoder, the link blocks built from them,
+// and the post-write metadata block every write tool reports alongside them.
 
 export const FILESYSTEM_FILE_URI_TEMPLATE = 'filesystem-mcp://file/{+path}';
 
@@ -44,23 +50,27 @@ export function buildFileResourceLinkFor(
   name: string,
   mimeType: string,
   size: number,
-  annotations: Record<string, unknown> = { audience: ['user', 'assistant'] },
 ): ContentBlock {
-  return { type: 'resource_link', uri, name, mimeType, size, annotations };
+  return {
+    type: 'resource_link',
+    uri,
+    name,
+    mimeType,
+    size,
+    annotations: { audience: ['user', 'assistant'] },
+  };
 }
 
 export function buildFileResourceLink(
   validPath: string,
   mimeType: string,
   size: number,
-  annotations: Record<string, unknown> = { audience: ['user', 'assistant'] },
 ): ContentBlock {
   return buildFileResourceLinkFor(
     buildFileResourceUri(validPath),
     basename(validPath),
     mimeType,
     size,
-    annotations,
   );
 }
 
@@ -72,4 +82,37 @@ export function extractPath(uri: string): string | undefined {
   } catch {
     return undefined;
   }
+}
+
+export interface WrittenFileMeta {
+  size: number;
+  lineCount: number;
+  mimeType: string;
+  kind: FileKind;
+  resourceUri: string;
+  /** Undefined when no resource store is configured — nothing to link into. */
+  resourceLink: ContentBlock | undefined;
+}
+
+/**
+ * The five-step block every write tool runs on its post-write content: size,
+ * line count, MIME, the file's resource URI, and the store-gated link block.
+ */
+export function buildWrittenFileMeta(
+  validPath: string,
+  content: string,
+  resourceStore: ResourceStore | undefined,
+): WrittenFileMeta {
+  const size = Buffer.byteLength(content, 'utf-8');
+  const mimeInfo = detectMimeFromContent(validPath, content);
+  return {
+    size,
+    lineCount: countLines(content),
+    mimeType: mimeInfo.mimeType,
+    kind: mimeInfo.kind,
+    resourceUri: buildFileResourceUri(validPath),
+    resourceLink: resourceStore
+      ? buildFileResourceLink(validPath, mimeInfo.mimeType, size)
+      : undefined,
+  };
 }

--- a/src/core/fs.ts
+++ b/src/core/fs.ts
@@ -1,6 +1,5 @@
 import { randomUUID } from 'node:crypto';
 import type { Stats } from 'node:fs';
-import { constants as fsConstants } from 'node:fs';
 import type { FileHandle } from 'node:fs/promises';
 import {
   chmod as fsChmod,
@@ -118,13 +117,6 @@ async function atomicWriteFile(
     throw error;
   }
   return { validPath };
-}
-
-export function getFileType(stats: Stats): FileType {
-  if (stats.isFile()) return 'file';
-  if (stats.isDirectory()) return 'directory';
-  if (stats.isSymbolicLink()) return 'symlink';
-  return 'other';
 }
 
 export function isHidden(name: string): boolean {
@@ -278,19 +270,9 @@ export class GuardedFileSystem {
     };
   }
 
-  async open(
-    filePath: string,
-    flags: string | number,
-    mode?: string | number,
-  ): Promise<FileHandle> {
-    // Only a plain read-only open ('r' / O_RDONLY) uses the existing-path guard.
-    // Every other flag (write, append, read-write, sync, numeric) is treated as
-    // write-capable and routed through the stricter write guard.
-    const isReadOnly = flags === 'r' || flags === fsConstants.O_RDONLY;
-    const validPath = isReadOnly
-      ? await this.pathGuard.validateExistingPath(filePath)
-      : await this.pathGuard.validatePathForWrite(filePath);
-    return fsOpen(validPath, flags, mode);
+  async open(filePath: string): Promise<FileHandle> {
+    const validPath = await this.pathGuard.validateExistingPath(filePath);
+    return fsOpen(validPath, 'r');
   }
 
   // Single resolution + stat: validateExistingPathDetailed resolves the real

--- a/src/core/glob.ts
+++ b/src/core/glob.ts
@@ -8,23 +8,10 @@ import { processInParallel } from './concurrency.js';
 import { formatUnknownErrorMessage } from './errors.js';
 import { Logger } from './observability.js';
 import { isWindowsDriveRelativePath } from './path-utils.js';
-import { toPosixPath } from './primitives.js';
+import { type DirentLike, toPosixPath } from './primitives.js';
 import type { EntryType } from './primitives.js';
 
 export type { EntryType };
-
-export interface DirentLike {
-  isDirectory(): boolean;
-  isFile(): boolean;
-  isSymbolicLink(): boolean;
-}
-
-export function resolveEntryType(dirent: DirentLike): EntryType {
-  if (dirent.isDirectory()) return 'directory';
-  if (dirent.isFile()) return 'file';
-  if (dirent.isSymbolicLink()) return 'symlink';
-  return 'other';
-}
 
 export function isSafeGlobSyntax(pattern: string): boolean {
   if (!pattern || pattern.trim().length === 0) {

--- a/src/core/primitives.ts
+++ b/src/core/primitives.ts
@@ -5,10 +5,23 @@ import { delimiter } from 'node:path';
  * Kept separate to avoid import cycles between observability.ts and util.ts.
  */
 
-/** The four filesystem entry types. Produced by `resolveEntryType` (glob.ts)
- *  and `getFileType` (fs.ts); published as the `FileType` schema. */
+/** The four filesystem entry types; published as the `FileType` schema. */
 export const ENTRY_TYPES = ['file', 'directory', 'symlink', 'other'] as const;
 export type EntryType = (typeof ENTRY_TYPES)[number];
+
+/** The three predicates both `Dirent` and `Stats` expose - all `resolveEntryType` needs. */
+export interface DirentLike {
+  isDirectory(): boolean;
+  isFile(): boolean;
+  isSymbolicLink(): boolean;
+}
+
+export function resolveEntryType(dirent: DirentLike): EntryType {
+  if (dirent.isDirectory()) return 'directory';
+  if (dirent.isFile()) return 'file';
+  if (dirent.isSymbolicLink()) return 'symlink';
+  return 'other';
+}
 
 const warnedFlagValues = new Set<string>();
 

--- a/src/core/schema.ts
+++ b/src/core/schema.ts
@@ -177,31 +177,6 @@ export const PathFailureSchema = z.strictObject({
   error: PerFileErrorSchema,
 });
 
-// TODO(future): Wrap createReadRangeFields output in a typed Zod object with built-in
-// cross-validation. Safe for now — the only caller (read.ts) calls validateReadRange in its own superRefine.
-interface ReadRangeDescriptions {
-  head: string;
-  tail: string;
-  startLine: string;
-  endLine: string;
-}
-
-export function createReadRangeFields(descs: ReadRangeDescriptions) {
-  const rangeField = (d: string) =>
-    z
-      .int32()
-      .min(1, { message: 'Min: 1' })
-      .max(100000, { message: 'Max: 100,000' })
-      .optional()
-      .describe(d);
-  return {
-    head: rangeField(descs.head),
-    tail: rangeField(descs.tail),
-    startLine: rangeField(descs.startLine),
-    endLine: rangeField(descs.endLine),
-  };
-}
-
 export function validateReadRange(
   value: {
     head?: number | undefined;
@@ -276,22 +251,19 @@ export type SingleOrBatchShape<TExtra extends z.ZodRawShape> = TExtra & {
   paths: z.ZodOptional<z.ZodArray<typeof RequiredPath>>;
 };
 
-export function singleOrBatchPathsInput<TExtra extends z.ZodRawShape>(opts: {
-  extra: TExtra;
-  maxBatch?: number;
-}): z.ZodObject<SingleOrBatchShape<TExtra>> {
-  const maxBatch = opts.maxBatch ?? DEFAULT_MAX_BATCH;
-
+export function singleOrBatchPathsInput<TExtra extends z.ZodRawShape>(
+  extra: TExtra,
+): z.ZodObject<SingleOrBatchShape<TExtra>> {
   const shape: z.ZodRawShape = {
-    ...opts.extra,
+    ...extra,
     path: RequiredPath.optional().describe('Single file path; mutually exclusive with paths'),
     paths: z
       .array(RequiredPath)
       .min(1)
-      .max(maxBatch)
+      .max(DEFAULT_MAX_BATCH)
       .optional()
       .describe(
-        `Array of file paths for batch mode (max ${String(maxBatch)}); mutually exclusive with path`,
+        `Array of file paths for batch mode (max ${String(DEFAULT_MAX_BATCH)}); mutually exclusive with path`,
       ),
   };
 

--- a/src/core/search.ts
+++ b/src/core/search.ts
@@ -1,4 +1,5 @@
 import { stat as fsStat, readFile } from 'node:fs/promises';
+import { basename } from 'node:path';
 
 import type { RE2ExecArray } from '@adguard/re2-wasm';
 import { RE2 } from '@adguard/re2-wasm';
@@ -311,11 +312,7 @@ export async function searchFiles(
   // Sorting — only name / path are supported; size / modified were removed
   // (the glob never collected stats, so they were always undefined).
   if (options.sortBy === 'name') {
-    results.sort((a, b) => {
-      const aName = a.path.split(/[/\\]/).pop() ?? '';
-      const bName = b.path.split(/[/\\]/).pop() ?? '';
-      return aName.localeCompare(bName);
-    });
+    results.sort((a, b) => basename(a.path).localeCompare(basename(b.path)));
   } else {
     results.sort((a, b) => a.path.localeCompare(b.path));
   }

--- a/src/tools/batch.ts
+++ b/src/tools/batch.ts
@@ -1,32 +1,9 @@
-import type { InputRequiredResult } from '@modelcontextprotocol/server';
-
 import { processInParallel } from '../core/concurrency.js';
-import { ErrorCode, FsError, Problem, rethrowIfAborted } from '../core/errors.js';
-import { choiceInput, pendingRoundTrip } from '../core/input-required.js';
-import { IS_CASE_INSENSITIVE_FS } from '../core/path-utils.js';
+import { ErrorCode, FsError, Problem } from '../core/errors.js';
 import { PARALLEL_CONCURRENCY } from '../core/util.js';
 import type { ToolCtx } from './define.js';
 
-interface PerPathError {
-  code: ErrorCode;
-  message: string;
-  path?: string;
-  suggestion?: string;
-}
-
-/** One entry of a source→destination tool's `failures[]` — move's failure schema is the wire twin. */
-export interface PairFailureItem {
-  source: string;
-  destination: string;
-  error: {
-    code: string;
-    message: string;
-    path?: string | undefined;
-    suggestion?: string | undefined;
-  };
-}
-
-export type PerPathResult<T> = { path: string; value: T } | { path: string; error: PerPathError };
+export type PerPathResult<T> = { path: string; value: T } | { path: string; error: Problem };
 
 export interface BatchResult<T> {
   results: PerPathResult<T>[];
@@ -90,7 +67,7 @@ export async function runOverPaths<TOverride, TPerPath>(
       } catch (error: unknown) {
         results[index] = {
           path: item.path,
-          error: Problem.toPerFileError(error, defaultErrorCode, item.path),
+          error: Problem.fromUnknown(error, defaultErrorCode, item.path),
         };
       } finally {
         tick();
@@ -112,191 +89,15 @@ export async function runOverPaths<TOverride, TPerPath>(
   };
 }
 
-/** The minimum a pair plan must expose for the shared driver to route it. */
-export interface PairPlan {
-  readonly pair: { source: string; destination: string };
-  readonly validDest: string;
-  readonly pending: boolean;
-}
-
-export type PairPlanResult<TPlan extends PairPlan> =
-  | { status: 'fail'; failure: PairFailureItem }
-  | { status: 'noop' }
-  | { status: 'plan'; plan: TPlan };
-
-/** A discriminated union, so the fold below narrows without a generic cast. */
-export type PairExecResult<TResult> = { readonly skipped: string } | { readonly value: TResult };
-
-export interface PairBatchOutcome<TResult> {
-  results: TResult[];
-  skipped: string[];
-  failures: PairFailureItem[];
-}
-
 /**
  * A batch where every requested item failed produced no work at all, so it is a
- * failed call — `isError` must say so. Partial failure is deliberately NOT an
+ * failed call - `isError` must say so. Partial failure is deliberately NOT an
  * error: the per-item entries carry which failed, and the succeeded ones really
- * were done. A skipped item is work the caller asked to skip, not work that
- * failed — a self-move that was silently dropped means the call did something.
- * Zero items is not a failure either.
- *
- * Takes either count shape a batch tool holds at its return site: a `summary`
- * (`runOverPaths`, or the hand-built ones in `read`, `delete`, `replace_text`)
- * or a pair outcome (`runOverPairs`).
+ * were done. Zero items is not a failure either.
  */
-export function isTotalFailure(
-  shape:
-    | { readonly total: number; readonly failed: number }
-    | {
-        readonly results: readonly unknown[];
-        readonly skipped: readonly unknown[];
-        readonly failures: readonly unknown[];
-      },
-): boolean {
-  if ('total' in shape) return shape.total > 0 && shape.failed === shape.total;
-  return shape.failures.length > 0 && shape.results.length + shape.skipped.length === 0;
-}
-
-export function pairFailure(
-  pair: { source: string; destination: string },
-  error: unknown,
-): PairFailureItem {
-  return {
-    source: pair.source,
-    destination: pair.destination,
-    error: Problem.toPerFileError(error, ErrorCode.UNKNOWN, pair.source),
-  };
-}
-
-interface RunOverPairsOptions<TItem, TPlan extends PairPlan, TResult> {
-  readonly op: 'copy' | 'move';
-  readonly plan: (item: TItem) => Promise<PairPlanResult<TPlan>>;
-  readonly execute: (
-    plan: TPlan,
-    pendingSorted: readonly string[],
-  ) => Promise<PairExecResult<TResult>>;
-}
-
-/**
- * The source→destination sibling of `runOverPaths`: plan every pair, fail closed
- * on a duplicated destination, round-trip the overwrite confirmations as one
- * set, then execute what survived in parallel. `copy` and `move` differ only in
- * their `plan` and `execute` callbacks.
- */
-export async function runOverPairs<TItem, TPlan extends PairPlan, TResult>(
-  items: readonly TItem[],
-  ctx: ToolCtx,
-  opts: RunOverPairsOptions<TItem, TPlan, TResult>,
-): Promise<PairBatchOutcome<TResult> | InputRequiredResult> {
-  const verb = opts.op === 'copy' ? 'Copy' : 'Move';
-
-  const { results: planned, errors: planErrors } = await processInParallel(
-    items,
-    opts.plan,
-    PARALLEL_CONCURRENCY,
-    ctx.signal,
-  );
-  // plan callbacks are fail-closed (they return { status: 'fail' }, never
-  // throw), so planErrors should always be empty. Surface the first rather
-  // than silently dropping the item if a future plan callback violates that.
-  const firstPlanError = planErrors[0];
-  if (firstPlanError) throw firstPlanError.error;
-
-  const failures: PairFailureItem[] = [];
-  const candidates: TPlan[] = [];
-  for (const { value } of planned) {
-    if (value.status === 'fail') failures.push(value.failure);
-    else if (value.status === 'plan') candidates.push(value.plan);
-    // 'noop' (self-copy / self-move) is silently skipped.
-  }
-
-  // Two sources targeting the same destination in one batch would otherwise
-  // collapse to a single shared overwrite confirmation and let the second
-  // one silently clobber the first's freshly-written content. Fail closed:
-  // only the first plan per destination proceeds; later ones targeting the
-  // same destination are reported as a per-item failure.
-  const seenDest = new Set<string>();
-  const ready: TPlan[] = [];
-  for (const plan of candidates) {
-    const destKey = IS_CASE_INSENSITIVE_FS ? plan.validDest.toLowerCase() : plan.validDest;
-    if (seenDest.has(destKey)) {
-      failures.push(
-        pairFailure(
-          plan.pair,
-          new FsError(
-            ErrorCode.INVALID_INPUT,
-            `${verb} cancelled: another entry in this batch already targets destination "${plan.pair.destination}"`,
-            plan.pair.destination,
-          ),
-        ),
-      );
-      continue;
-    }
-    seenDest.add(destKey);
-    ready.push(plan);
-  }
-
-  const pendingSorted = ready
-    .filter((p) => p.pending)
-    .map((p) => p.validDest)
-    .sort();
-  if (pendingSorted.length > 0) {
-    // Round 1 returns input_required; a retry whose verified state does not
-    // bind this overwrite set throws (R9) via `pendingRoundTrip`.
-    const round = await pendingRoundTrip({
-      op: opts.op,
-      pending: pendingSorted,
-      requestState: ctx.requestState,
-      clientCapabilities: ctx.clientCapabilities,
-      buildInputs: (dests) =>
-        dests.map((dest, i) =>
-          choiceInput(
-            `confirm_${i}`,
-            opts.op === 'move'
-              ? `"${dest}" already exists. Overwrite it?`
-              : `Destination "${dest}" already exists. Overwrite it?`,
-            [
-              { value: 'overwrite', title: 'Overwrite' },
-              { value: 'skip', title: 'Skip' },
-            ],
-          ),
-        ),
-    });
-    if (round !== undefined) return round;
-  }
-
-  const total = ready.length;
-  let completed = 0;
-  const tick = (): void => {
-    completed += 1;
-    ctx.onProgress?.({ current: completed, total });
-  };
-  const { results: execResults, errors: execErrors } = await processInParallel(
-    ready,
-    async (plan) => {
-      try {
-        return await opts.execute(plan, pendingSorted);
-      } finally {
-        tick();
-      }
-    },
-    PARALLEL_CONCURRENCY,
-    ctx.signal,
-  );
-
-  for (const { error, index } of execErrors) {
-    rethrowIfAborted(error);
-    const plan = ready[index];
-    if (plan) failures.push(pairFailure(plan.pair, error));
-  }
-
-  const results: TResult[] = [];
-  const skipped: string[] = [];
-  for (const { value } of execResults) {
-    if ('skipped' in value) skipped.push(value.skipped);
-    else results.push(value.value);
-  }
-
-  return { results, skipped, failures };
+export function isTotalFailure(summary: {
+  readonly total: number;
+  readonly failed: number;
+}): boolean {
+  return summary.total > 0 && summary.failed === summary.total;
 }

--- a/src/tools/create.ts
+++ b/src/tools/create.ts
@@ -5,9 +5,7 @@ import { basename, dirname } from 'node:path';
 import * as z from 'zod/v4';
 
 import { ErrorCode } from '../core/errors.js';
-import { buildFileResourceLink, buildFileResourceUri } from '../core/file-uri.js';
-import { detectMimeFromContent } from '../core/mime.js';
-import { countLines } from '../core/read.js';
+import { buildWrittenFileMeta } from '../core/file-uri.js';
 import {
   FileKind,
   IsoDateTime,
@@ -96,28 +94,20 @@ export const CREATE = defineTool({
         });
 
         const { stats: fileStats } = await ctx.fs.stat(path, { signal: ctx.signal });
-        const bytesWritten = Buffer.byteLength(content, 'utf-8');
-        const lineCount = countLines(content);
-        const mimeInfo = detectMimeFromContent(validPath, content);
+        const meta = buildWrittenFileMeta(validPath, content, ctx.resourceStore);
 
-        const resourceUri = buildFileResourceUri(validPath);
         const file: CreateFileResult = {
           path: validPath,
-          size: bytesWritten,
-          lineCount,
-          mimeType: mimeInfo.mimeType,
-          kind: mimeInfo.kind,
-          resourceUri,
+          size: meta.size,
+          lineCount: meta.lineCount,
+          mimeType: meta.mimeType,
+          kind: meta.kind,
+          resourceUri: meta.resourceUri,
           created: fileStats.birthtime.toISOString(),
           modified: fileStats.mtime.toISOString(),
         };
 
-        return ctx.resourceStore
-          ? {
-              file,
-              resourceLink: buildFileResourceLink(validPath, mimeInfo.mimeType, bytesWritten),
-            }
-          : { file };
+        return meta.resourceLink ? { file, resourceLink: meta.resourceLink } : { file };
       },
       { defaultErrorCode: ErrorCode.UNKNOWN },
     );

--- a/src/tools/define.ts
+++ b/src/tools/define.ts
@@ -43,7 +43,6 @@ import { McpProgressSink, ProgressSession } from './progress.js';
 
 export interface ToolCtx {
   readonly signal: AbortSignal;
-  readonly sessionId?: string;
   readonly authInfo?: AuthInfo;
   readonly _meta?: RequestMeta | undefined;
   readonly fs: GuardedFileSystem;
@@ -80,7 +79,6 @@ export interface ToolCtx {
    * all. `undefined` means "cannot tell" — never "no capabilities".
    */
   readonly clientCapabilities?: ClientCapabilities | undefined;
-  readonly server?: McpServer;
 }
 
 interface ToolDeps {
@@ -153,7 +151,6 @@ function toToolCtx(
       fs: new GuardedFileSystem(deps.pathGuard),
       pageStore: deps.pageStore,
       resourceStore: deps.resourceStore,
-      server: deps.server,
     };
   }
   // Envelope first, accessor second — the two eras carry this differently.
@@ -176,7 +173,6 @@ function toToolCtx(
 
   return {
     signal: ctx.mcpReq.signal,
-    ...(ctx.sessionId ? { sessionId: ctx.sessionId } : {}),
     ...(ctx.http?.authInfo ? { authInfo: ctx.http.authInfo } : {}),
     ...(ctx.mcpReq._meta ? { _meta: ctx.mcpReq._meta } : {}),
     fs: new GuardedFileSystem(deps.pathGuard),
@@ -186,7 +182,6 @@ function toToolCtx(
     inputResponses: ctx.mcpReq.inputResponses,
     requestState: ctx.mcpReq.requestState,
     ...(clientCapabilities ? { clientCapabilities } : {}),
-    server: deps.server,
   };
 }
 

--- a/src/tools/delete-file.ts
+++ b/src/tools/delete-file.ts
@@ -16,8 +16,8 @@ import {
 } from '../core/errors.js';
 import { joinRoster, pathLabel } from '../core/fmt.js';
 import type { FileType, GuardedFileSystem } from '../core/fs.js';
-import { getFileType } from '../core/fs.js';
 import { choiceInput, pendingRoundTrip, readAcceptedChoice } from '../core/input-required.js';
+import { resolveEntryType } from '../core/primitives.js';
 import {
   defaultFalseBoolean,
   OperationSummarySchema,
@@ -75,12 +75,7 @@ interface DeletedItem {
 }
 interface DeleteFailure {
   path: string;
-  error: {
-    code: string;
-    message: string;
-    path?: string;
-    suggestion?: string;
-  };
+  error: Problem;
 }
 
 const ERR_NOT_EMPTY = new Error('Directory not empty. Set recursive: true.');
@@ -93,7 +88,7 @@ function toDeleteFailure(path: string, error: unknown): DeleteFailure {
   if (isNotFoundErrno(error)) {
     return {
       path,
-      error: Problem.toPerFileError(
+      error: Problem.fromUnknown(
         new FsError(ErrorCode.NOT_FOUND, 'Path not found', path),
         ErrorCode.NOT_FOUND,
         path,
@@ -106,10 +101,10 @@ function toDeleteFailure(path: string, error: unknown): DeleteFailure {
   ) {
     return {
       path,
-      error: Problem.toPerFileError(ERR_NOT_EMPTY, ErrorCode.INVALID_INPUT, path),
+      error: Problem.fromUnknown(ERR_NOT_EMPTY, ErrorCode.INVALID_INPUT, path),
     };
   }
-  return { path, error: Problem.toPerFileError(error, ErrorCode.UNKNOWN, path) };
+  return { path, error: Problem.fromUnknown(error, ErrorCode.UNKNOWN, path) };
 }
 
 type LstatResult = Awaited<ReturnType<GuardedFileSystem['lstat']>>;
@@ -178,7 +173,7 @@ async function planPath(
     return { status: 'fail', failure: toDeleteFailure(inputPath, error) };
   }
 
-  const itemType = getFileType(firstStats.stats);
+  const itemType = resolveEntryType(firstStats.stats);
   let hasChildren = false;
   if (args.recursive && itemType === 'directory') {
     try {
@@ -227,7 +222,7 @@ async function finalizeDeletion(
     return { failure: toDeleteFailure(plan.inputPath, error) };
   }
 
-  const currentItemType = getFileType(currentStats.stats);
+  const currentItemType = resolveEntryType(currentStats.stats);
   // Identity comparison, not just the coarse category: a swap during the
   // confirmation gap (delete original, create a same-named replacement) keeps
   // the type but changes dev/ino/birthtimeMs. birthtimeMs is the primary

--- a/src/tools/diff.ts
+++ b/src/tools/diff.ts
@@ -3,8 +3,9 @@ import type { ContentBlock } from '@modelcontextprotocol/server';
 import { basename } from 'node:path';
 
 import * as z from 'zod/v4';
-import { createTwoFilesPatch, diffLines } from 'diff';
+import { createTwoFilesPatch } from 'diff';
 
+import { computeDiffStats } from '../core/diff.js';
 import { NonNegInt, PositiveInt, RequiredPath } from '../core/schema.js';
 import { putJsonResource } from '../core/store.js';
 import { defineTool, type ToolCtx } from './define.js';
@@ -58,13 +59,7 @@ async function handleDiff(
     { context: args.context },
   );
 
-  // diffLines returns the change list synchronously; count added/removed lines.
-  let linesAdded = 0;
-  let linesRemoved = 0;
-  for (const part of diffLines(contentA, contentB)) {
-    if (part.added) linesAdded += part.count;
-    else if (part.removed) linesRemoved += part.count;
-  }
+  const { linesAdded, linesRemoved } = computeDiffStats(contentA, contentB);
 
   let resourceUri: string | undefined;
   let link: ReturnType<typeof putJsonResource>['link'] | undefined;

--- a/src/tools/edit.ts
+++ b/src/tools/edit.ts
@@ -3,13 +3,11 @@ import type { ContentBlock } from '@modelcontextprotocol/server';
 import { basename } from 'node:path';
 
 import * as z from 'zod/v4';
-import { createTwoFilesPatch, diffLines } from 'diff';
 
+import { computeDiffStats, unifiedPatch } from '../core/diff.js';
 import { ErrorCode, FsError } from '../core/errors.js';
-import { buildFileResourceLink, buildFileResourceUri } from '../core/file-uri.js';
-import { detectMimeFromContent } from '../core/mime.js';
+import { buildWrittenFileMeta, type WrittenFileMeta } from '../core/file-uri.js';
 import { escapeRegexLiteral } from '../core/primitives.js';
-import { countLines } from '../core/read.js';
 import {
   defaultFalseBoolean,
   FileKind,
@@ -176,20 +174,6 @@ interface EditResult {
   lineRange?: [number, number];
 }
 
-function computeDiffStats(
-  original: string,
-  modified: string,
-): { linesAdded: number; linesRemoved: number } {
-  // diffLines returns the change list synchronously on diff v9.
-  let linesAdded = 0;
-  let linesRemoved = 0;
-  for (const part of diffLines(original, modified)) {
-    if (part.added) linesAdded += part.count;
-    else if (part.removed) linesRemoved += part.count;
-  }
-  return { linesAdded, linesRemoved };
-}
-
 function findEditMatch(
   content: string,
   oldText: string,
@@ -293,7 +277,7 @@ function buildEditFileValue(
 ): EditFileValue {
   return {
     path: validPath,
-    size: meta.bytesWritten,
+    size: meta.size,
     lineCount: meta.lineCount,
     mimeType: meta.mimeType,
     kind: meta.kind,
@@ -331,15 +315,11 @@ function finalizeEditResult(
   };
 }
 
-interface EditFileMetadata {
-  bytesWritten: number;
-  lineCount: number;
-  mimeType: string;
-  kind: FileKind;
-  /** Undefined when no edit matched: there is no updated content to point at. */
+/** {@link WrittenFileMeta}, with `resourceUri` widened: an edit that matched
+ *  nothing has no updated content to point at. */
+type EditFileMetadata = Omit<WrittenFileMeta, 'resourceUri'> & {
   resourceUri: string | undefined;
-  resourceLink: ContentBlock | undefined;
-}
+};
 
 function buildEditFileMetadata(
   content: string,
@@ -347,23 +327,14 @@ function buildEditFileMetadata(
   appliedEdits: number,
   resourceStore: ResourceStore | undefined,
 ): EditFileMetadata {
-  const bytesWritten = Buffer.byteLength(content, 'utf-8');
-  const lineCount = countLines(content);
-  const mimeInfo = detectMimeFromContent(validPath, content);
+  const meta = buildWrittenFileMeta(validPath, content, resourceStore);
   // Omitted rather than empty-stringed when nothing matched: `""` satisfied the
   // schema's `string` and then failed every resources/read a client tried it on.
-  const resourceUri = appliedEdits > 0 ? buildFileResourceUri(validPath) : undefined;
-  const resourceLink =
-    appliedEdits > 0 && resourceStore
-      ? buildFileResourceLink(validPath, mimeInfo.mimeType, bytesWritten)
-      : undefined;
+  const written = appliedEdits > 0;
   return {
-    bytesWritten,
-    lineCount,
-    mimeType: mimeInfo.mimeType,
-    kind: mimeInfo.kind,
-    resourceUri,
-    resourceLink,
+    ...meta,
+    resourceUri: written ? meta.resourceUri : undefined,
+    resourceLink: written ? meta.resourceLink : undefined,
   };
 }
 
@@ -421,17 +392,7 @@ async function handleEditFile(
 
   if (options.dryRun) {
     if (editResult.appliedEdits > 0) {
-      const label = basename(validPath);
-      // createTwoFilesPatch returns the unified diff string synchronously on
-      // diff v9 (the { callback } option fires via setTimeout and returns undefined).
-      editResult.diff = createTwoFilesPatch(
-        label,
-        label,
-        content,
-        editResult.content,
-        'Original',
-        'Modified',
-      );
+      editResult.diff = unifiedPatch(basename(validPath), content, editResult.content);
     }
 
     // Nothing was written, so there is no updated content to point a

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -38,8 +38,6 @@ export const MUTATING_TOOL_NAMES = new Set(
   ALL_TOOLS.filter((t) => !t.annotations.readOnlyHint).map((t) => t.name),
 );
 
-export const ALL_REGISTERED_TOOL_NAMES: readonly string[] = ALL_TOOLS.map((t) => t.name);
-
 /** The tools a server registers at this setting — the one owner of the `--read-only` gate. */
 export function registeredTools(readOnly: boolean): readonly DefinedTool[] {
   return readOnly ? ALL_TOOLS.filter((t) => !MUTATING_TOOL_NAMES.has(t.name)) : ALL_TOOLS;

--- a/src/tools/list.ts
+++ b/src/tools/list.ts
@@ -13,10 +13,10 @@ import {
   globEntries,
   isIgnoredByGitignore,
   loadRootGitignore,
-  resolveEntryType,
 } from '../core/glob.js';
 import type { PathGuard } from '../core/path.js';
 import { toPosixRelative } from '../core/path.js';
+import { resolveEntryType } from '../core/primitives.js';
 import {
   CursorSchema,
   FileType as FileTypeEnum,

--- a/src/tools/move.ts
+++ b/src/tools/move.ts
@@ -5,6 +5,7 @@ import { basename, dirname, resolve } from 'node:path';
 
 import * as z from 'zod/v4';
 
+import { processInParallel } from '../core/concurrency.js';
 import {
   ErrorCode,
   FsError,
@@ -16,11 +17,10 @@ import {
 import { joinRoster, pathLabel } from '../core/fmt.js';
 import { destExists } from '../core/fs.js';
 import type { GuardedFileSystem } from '../core/fs.js';
-import { readAcceptedChoice } from '../core/input-required.js';
-import { isPathInsideDirectory, isSamePath } from '../core/path-utils.js';
+import { choiceInput, pendingRoundTrip, readAcceptedChoice } from '../core/input-required.js';
+import { IS_CASE_INSENSITIVE_FS, isPathInsideDirectory, isSamePath } from '../core/path-utils.js';
 import { defaultFalseBoolean, PerFileErrorSchema, RequiredPath } from '../core/schema.js';
-import type { PairExecResult, PairPlanResult } from './batch.js';
-import { isTotalFailure, pairFailure, runOverPairs } from './batch.js';
+import { PARALLEL_CONCURRENCY } from '../core/util.js';
 import type { ToolCtx } from './define.js';
 import { defineTool } from './define.js';
 
@@ -106,7 +106,7 @@ async function planTransfer(
   pair: { source: string; destination: string },
   fs: ToolCtx['fs'],
   overwrite: boolean,
-): Promise<PairPlanResult<TransferPlan>> {
+): Promise<TransferPlanResult> {
   let realSource: string;
   let opSource: string;
   let validDest: string;
@@ -167,7 +167,7 @@ async function executeTransfer(
   plan: TransferPlan,
   ctx: Pick<ToolCtx, 'fs' | 'signal' | 'inputResponses' | 'log'>,
   pendingSorted: readonly string[],
-): Promise<PairExecResult<MoveItemResult>> {
+): Promise<TransferExecResult> {
   if (plan.pending) {
     const key = `confirm_${pendingSorted.indexOf(plan.validDest)}`;
     const choice = readAcceptedChoice(ctx.inputResponses, key);
@@ -213,6 +213,152 @@ async function executeTransfer(
   return { value: { from: plan.opSource, to: plan.validDest } };
 }
 
+type TransferPlanResult =
+  | { status: 'fail'; failure: MoveFailureItem }
+  | { status: 'noop' }
+  | { status: 'plan'; plan: TransferPlan };
+
+/** A discriminated union, so the fold below narrows without a generic cast. */
+type TransferExecResult = { readonly skipped: string } | { readonly value: MoveItemResult };
+
+function pairFailure(
+  pair: { source: string; destination: string },
+  error: unknown,
+): MoveFailureItem {
+  return {
+    source: pair.source,
+    destination: pair.destination,
+    error: Problem.fromUnknown(error, ErrorCode.UNKNOWN, pair.source),
+  };
+}
+
+/**
+ * The source→destination sibling of `runOverPaths`: plan every pair, fail closed
+ * on a duplicated destination, round-trip the overwrite confirmations as one
+ * set, then execute what survived in parallel. `copy` and `move` differ only in
+ * their `plan` and `execute` callbacks.
+ */
+async function runTransfers(
+  items: readonly z.infer<typeof MoveItemSchema>[],
+  ctx: ToolCtx,
+  op: PairOp,
+  overwrite: boolean,
+): Promise<
+  | { results: MoveItemResult[]; skipped: string[]; failures: MoveFailureItem[] }
+  | InputRequiredResult
+> {
+  const { results: planned, errors: planErrors } = await processInParallel(
+    items,
+    (pair) => planTransfer(op, pair, ctx.fs, overwrite),
+    PARALLEL_CONCURRENCY,
+    ctx.signal,
+  );
+  // plan callbacks are fail-closed (they return { status: 'fail' }, never
+  // throw), so planErrors should always be empty. Surface the first rather
+  // than silently dropping the item if a future plan callback violates that.
+  const firstPlanError = planErrors[0];
+  if (firstPlanError) throw firstPlanError.error;
+
+  const failures: MoveFailureItem[] = [];
+  const candidates: TransferPlan[] = [];
+  for (const { value } of planned) {
+    if (value.status === 'fail') failures.push(value.failure);
+    else if (value.status === 'plan') candidates.push(value.plan);
+    // 'noop' (self-copy / self-move) is silently skipped.
+  }
+
+  // Two sources targeting the same destination in one batch would otherwise
+  // collapse to a single shared overwrite confirmation and let the second
+  // one silently clobber the first's freshly-written content. Fail closed:
+  // only the first plan per destination proceeds; later ones targeting the
+  // same destination are reported as a per-item failure.
+  const seenDest = new Set<string>();
+  const ready: TransferPlan[] = [];
+  for (const candidate of candidates) {
+    const destKey = IS_CASE_INSENSITIVE_FS
+      ? candidate.validDest.toLowerCase()
+      : candidate.validDest;
+    if (seenDest.has(destKey)) {
+      failures.push(
+        pairFailure(
+          candidate.pair,
+          new FsError(
+            ErrorCode.INVALID_INPUT,
+            `${VERB[op]} cancelled: another entry in this batch already targets destination "${candidate.pair.destination}"`,
+            candidate.pair.destination,
+          ),
+        ),
+      );
+      continue;
+    }
+    seenDest.add(destKey);
+    ready.push(candidate);
+  }
+
+  const pendingSorted = ready
+    .filter((p) => p.pending)
+    .map((p) => p.validDest)
+    .sort();
+  if (pendingSorted.length > 0) {
+    // Round 1 returns input_required; a retry whose verified state does not
+    // bind this overwrite set throws (R9) via `pendingRoundTrip`.
+    const round = await pendingRoundTrip({
+      op,
+      pending: pendingSorted,
+      requestState: ctx.requestState,
+      clientCapabilities: ctx.clientCapabilities,
+      buildInputs: (dests) =>
+        dests.map((dest, i) =>
+          choiceInput(
+            `confirm_${i}`,
+            op === 'move'
+              ? `"${dest}" already exists. Overwrite it?`
+              : `Destination "${dest}" already exists. Overwrite it?`,
+            [
+              { value: 'overwrite', title: 'Overwrite' },
+              { value: 'skip', title: 'Skip' },
+            ],
+          ),
+        ),
+    });
+    if (round !== undefined) return round;
+  }
+
+  const total = ready.length;
+  let completed = 0;
+  const tick = (): void => {
+    completed += 1;
+    ctx.onProgress?.({ current: completed, total });
+  };
+  const { results: execResults, errors: execErrors } = await processInParallel(
+    ready,
+    async (readyPlan) => {
+      try {
+        return await executeTransfer(op, readyPlan, ctx, pendingSorted);
+      } finally {
+        tick();
+      }
+    },
+    PARALLEL_CONCURRENCY,
+    ctx.signal,
+  );
+
+  for (const { error, index } of execErrors) {
+    rethrowIfAborted(error);
+    const failed = ready[index];
+    if (failed) failures.push(pairFailure(failed.pair, error));
+  }
+
+  const results: MoveItemResult[] = [];
+  const skipped: string[] = [];
+  for (const { value } of execResults) {
+    if ('skipped' in value) skipped.push(value.skipped);
+    else results.push(value.value);
+  }
+
+  return { results, skipped, failures };
+}
+
 /**
  * Two-phase move: pre-check every move (no mutation) to build the overwrite
  * pending set; if any move is pending and the round carries no verified
@@ -227,11 +373,7 @@ async function handleMove(
   const op: PairOp = args.copy ? 'copy' : 'move';
   // `overwrite` is copy-only; move has no confirmation bypass.
   const overwrite = args.copy && args.overwrite;
-  const outcome = await runOverPairs(args.moves, ctx, {
-    op,
-    plan: (pair) => planTransfer(op, pair, ctx.fs, overwrite),
-    execute: (plan, pendingSorted) => executeTransfer(op, plan, ctx, pendingSorted),
-  });
+  const outcome = await runTransfers(args.moves, ctx, op, overwrite);
   if (isInputRequiredResult(outcome)) return outcome;
 
   const { results, skipped, failures } = outcome;
@@ -391,7 +533,9 @@ export const MOVE = defineTool({
     return {
       structured: output,
       text: buildSummary(args.copy ? 'copy' : 'move', output.moves, failures, skipped),
-      isError: isTotalFailure({ results: output.moves, skipped, failures }),
+      // Every requested pair failed: no move, no copy, no user-chosen skip - the
+      // call did nothing. A skip is work the caller asked for, so it counts.
+      isError: failures.length > 0 && output.moves.length + skipped.length === 0,
     };
   },
 });

--- a/src/tools/patch.ts
+++ b/src/tools/patch.ts
@@ -6,9 +6,7 @@ import * as z from 'zod/v4';
 import { applyPatch, parsePatch } from 'diff';
 
 import { ErrorCode, FsError } from '../core/errors.js';
-import { buildFileResourceLink, buildFileResourceUri } from '../core/file-uri.js';
-import { detectMimeFromContent } from '../core/mime.js';
-import { countLines } from '../core/read.js';
+import { buildWrittenFileMeta } from '../core/file-uri.js';
 import {
   defaultFalseBoolean,
   FileKind,
@@ -39,37 +37,6 @@ const PatchOutputSchema = z.strictObject({
   linesRemoved: NonNegInt.describe('Number of lines removed by the patch'),
   diff: z.string().optional().describe('Unified diff preview (present only in dryRun mode)'),
 });
-
-interface PatchMeta {
-  size: number;
-  lineCount: number;
-  mimeType: string;
-  kind: FileKind;
-  resourceUri: string;
-  link: ContentBlock | undefined;
-}
-
-function buildPatchMeta(
-  validPath: string,
-  patched: string,
-  resourceStore: ToolCtx['resourceStore'],
-): PatchMeta {
-  const bytesWritten = Buffer.byteLength(patched, 'utf-8');
-  const mimeInfo = detectMimeFromContent(validPath, patched);
-  const resourceUri = buildFileResourceUri(validPath);
-  const link =
-    resourceStore !== undefined
-      ? buildFileResourceLink(validPath, mimeInfo.mimeType, bytesWritten)
-      : undefined;
-  return {
-    size: bytesWritten,
-    lineCount: countLines(patched),
-    mimeType: mimeInfo.mimeType,
-    kind: mimeInfo.kind,
-    resourceUri,
-    link,
-  };
-}
 
 // Hunk lines are the raw unified lines with their +/-/ leading prefix (no
 // +++/--- file headers inside hunks), so the first char is a reliable marker.
@@ -139,7 +106,7 @@ async function handlePatch(
   const summaryText = `patch: ${basename(args.path)} +${String(linesAdded)} -${String(linesRemoved)}`;
 
   if (args.dryRun) {
-    const meta = buildPatchMeta(validPath, patched, ctx.resourceStore);
+    const meta = buildWrittenFileMeta(validPath, patched, ctx.resourceStore);
     return {
       structured: {
         path: validPath,
@@ -156,7 +123,7 @@ async function handlePatch(
       // A dry run exists to be previewed, so it keeps returning the patched
       // text; only the write path summarizes, where the bytes are on disk.
       text: patched,
-      ...(meta.link !== undefined ? { resources: [meta.link] } : {}),
+      ...(meta.resourceLink !== undefined ? { resources: [meta.resourceLink] } : {}),
     };
   }
 
@@ -167,7 +134,7 @@ async function handlePatch(
   // writer it may reflect that writer's mtime while `size`/content come from this
   // patch's atomic write. The file content itself is always consistent.
   const { stats: fileStats } = await ctx.fs.stat(args.path, { signal: ctx.signal });
-  const meta = buildPatchMeta(validPath, patched, ctx.resourceStore);
+  const meta = buildWrittenFileMeta(validPath, patched, ctx.resourceStore);
   return {
     structured: {
       path: validPath,
@@ -181,7 +148,7 @@ async function handlePatch(
       linesRemoved,
     },
     text: summaryText,
-    ...(meta.link !== undefined ? { resources: [meta.link] } : {}),
+    ...(meta.resourceLink !== undefined ? { resources: [meta.resourceLink] } : {}),
   };
 }
 

--- a/src/tools/read.ts
+++ b/src/tools/read.ts
@@ -14,7 +14,6 @@ import type { ReadFileResult, ReadSpec } from '../core/read.js';
 import { readFileWithStats } from '../core/read.js';
 import {
   ContinuationSchema,
-  createReadRangeFields,
   defaultFalseBoolean,
   FileKind,
   NonNegInt,
@@ -38,20 +37,24 @@ import { isTotalFailure, runOverPaths } from './batch.js';
 import type { ToolCtx } from './define.js';
 import { defineTool } from './define.js';
 
-const readRangeFields = createReadRangeFields({
-  head: 'Return first N lines',
-  tail: 'Return last N lines',
-  startLine: 'Start line (1-indexed)',
-  endLine: 'End line (1-indexed)',
-});
+const rangeField = (description: string) =>
+  z
+    .int32()
+    .min(1, { message: 'Min: 1' })
+    .max(100000, { message: 'Max: 100,000' })
+    .optional()
+    .describe(description);
+
+const readRangeFields = {
+  head: rangeField('Return first N lines'),
+  tail: rangeField('Return last N lines'),
+  startLine: rangeField('Start line (1-indexed)'),
+  endLine: rangeField('End line (1-indexed)'),
+};
 
 const ReadFileInputSchema = singleOrBatchPathsInput({
-  extra: {
-    includeHash: defaultFalseBoolean(
-      'Include SHA-256 hash of the returned content in the response',
-    ),
-    ...readRangeFields,
-  },
+  includeHash: defaultFalseBoolean('Include SHA-256 hash of the returned content in the response'),
+  ...readRangeFields,
 })
   .superRefine((value, ctx) => {
     validateReadRange(

--- a/src/tools/replace-in-files.ts
+++ b/src/tools/replace-in-files.ts
@@ -4,10 +4,10 @@ import { Buffer } from 'node:buffer';
 import { dirname, join } from 'node:path';
 
 import * as z from 'zod/v4';
-import { createTwoFilesPatch } from 'diff';
 
 import type { StoppedReason, StopReasonTracker } from '../core/concurrency.js';
 import { processEntriesConcurrently, StoppedReasonSchema } from '../core/concurrency.js';
+import { unifiedPatch } from '../core/diff.js';
 import {
   ErrorCode,
   formatUnknownErrorMessage,
@@ -356,7 +356,6 @@ async function processEntry(entryPath: string, ctx: ReplaceContext): Promise<voi
       originalContent: plan.originalContent,
       updatedContent: plan.updatedContent,
       includeDiff: options.dryRun || options.returnDiff,
-      ...(signal ? { signal } : {}),
     });
   } catch (error) {
     summary.failedFiles++;
@@ -372,7 +371,7 @@ async function readReplacementPlan(
   ctx: ReplaceContext,
 ): Promise<ReplacementPlan | undefined> {
   const { matcher, replacement, maxFileSize, signal } = ctx;
-  await using fileHandle = await ctx.fs.open(validPath, 'r');
+  await using fileHandle = await ctx.fs.open(validPath);
   const stats = await fileHandle.stat();
   if (stats.size > maxFileSize) {
     throw new FsError(
@@ -394,22 +393,12 @@ function maybeAppendPatchDiff(
     originalContent: string;
     updatedContent: string;
     includeDiff: boolean;
-    signal?: AbortSignal;
   },
 ): void {
   if (!params.includeDiff) return;
   const header = toPosixRelative(summary.root, params.filePath);
 
-  // createTwoFilesPatch returns the unified diff string synchronously on
-  // diff v9 (the { callback } option fires via setTimeout and returns undefined).
-  const patch = createTwoFilesPatch(
-    header,
-    header,
-    params.originalContent,
-    params.updatedContent,
-    'Original',
-    'Modified',
-  );
+  const patch = unifiedPatch(header, params.originalContent, params.updatedContent);
 
   if (summary.diff.length >= MAX_DIFF_SIZE) {
     summary.diffTruncated = true;

--- a/src/tools/stat.ts
+++ b/src/tools/stat.ts
@@ -6,8 +6,9 @@ import * as z from 'zod/v4';
 
 import { ErrorCode, rethrowIfAborted } from '../core/errors.js';
 import type { FileInfo, GuardedFileSystem, Stats } from '../core/fs.js';
-import { getFileType, isHidden } from '../core/fs.js';
+import { isHidden } from '../core/fs.js';
 import { detectMimeType } from '../core/mime.js';
+import { resolveEntryType } from '../core/primitives.js';
 import {
   FileInfoSchema,
   NonNegInt,
@@ -23,7 +24,7 @@ import { isTotalFailure, runOverPaths } from './batch.js';
 import type { ToolCtx } from './define.js';
 import { defineTool } from './define.js';
 
-const StatInputSchema = singleOrBatchPathsInput({ extra: {} });
+const StatInputSchema = singleOrBatchPathsInput({});
 
 const StatPerPathSchema = z.strictObject({
   path: z.string().describe('Requested path'),
@@ -67,7 +68,7 @@ function buildFileInfoResult(
   return {
     name,
     path: requestedPath,
-    type: isSymlink ? 'symlink' : getFileType(stats),
+    type: isSymlink ? 'symlink' : resolveEntryType(stats),
     size: stats.size,
     ...(tokenEstimate !== undefined ? { tokenEstimate } : {}),
     created: stats.birthtime,


### PR DESCRIPTION
Applies the 17 confirmed findings from the 2026-09-07 full-repo over-engineering audit — 16 in scope; the `--safe` CLI alias was excluded as documented public surface — then the 10 shape fixes the `qc` review returned on top of them.

Behavior-preserving throughout: no schema change on the wire, no new features. **28 code files, +337 / −502.**

## Deduplication

- Fold `runOverPairs` and its five support types out of `batch.ts` into `move.ts` as a non-generic `runTransfers`. The generic driver had exactly one instantiation. `isTotalFailure` narrows to `{ total, failed }`, with the pair-shape branch inlined at move's one call site.
- Collapse four hand-declared copies of `{code, message, path?, suggestion?}` onto `Problem`, then delete `Problem.toPerFileError`, which the collapse left as a pass-through over `fromUnknown`.
- Extract `buildWrittenFileMeta` for the post-write block written three times. `EditFileMetadata` becomes `Omit<WrittenFileMeta, 'resourceUri'>` rather than a fifth copy of the shape.
- Extract `computeDiffStats` and `unifiedPatch` into a new `src/core/diff.ts`.

## Ownership

- Move `resolveEntryType` and `DirentLike` from `core/glob.ts` to `core/primitives.ts`, which already owns `ENTRY_TYPES`. Delete `getFileType`, its duplicate in `core/fs.ts`. `stat.ts`, `delete-file.ts` and `list.ts` no longer route through the glob module for a type name.
- Move the test-only tool-name inventory into `__tests__/helpers.ts` as one export.

## Dead surface removed

`ToolCtx.sessionId` · `ToolCtx.server` · `singleOrBatchPathsInput`'s `maxBatch` and its one-field options bag · the never-passed `annotations` param on both link builders · `createReadRangeFields` · `ALL_REGISTERED_TOOL_NAMES` · `Problem.ioError` · `maybeAppendPatchDiff`'s unread `signal` · the unreachable write branch of `GuardedFileSystem.open`.

## One deliberate behavior change

`searchFiles` `sortBy: 'name'` now uses `basename()` instead of splitting on `[/\]`. The old comparator treated a backslash as a separator, which is wrong on POSIX where `\` is a legal filename character; its `?? ''` fallback was also dead, since `split` never returns an empty array. `TC-FUNC-039b` covers the branch, which previously had no test.

## Review

| Stage | Result |
| :--- | :--- |
| `plan-hunt` | 1 confirmed dead step, fixed before execution; 4 killed |
| `bug-hunt` | Zero findings; 2 candidates raised, both refuted |
| `qc` | REQUEST_CHANGES on shape only, no behavior objection; all 10 items applied |

Gate: `node scripts/tasks.mjs` exits 0 — build, both type-checks, eslint, prettier, knip clean, **277 tests / 61 suites / 0 failures** (276 baseline plus `TC-FUNC-039b`).

The plan, its adversarial hunt, the run log with three recorded deviations, and the bug-hunt report are in `docs/plan/2026-09-07-overeng-residue/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G2VXbq4E56Br7merUxSPQb
