### PR TITLE
fix(search): correct RE2 code-point offsets to UTF-16

### DIFF
--- a/__tests__/tools.test.ts
+++ b/__tests__/tools.test.ts
@@ -1159,6 +1159,57 @@ describe('P0 Functional Tests - Tools (MCP Client)', () => {
     assert.strictEqual(content, 'QUX bar QUX\n');
   });
 
+  // RE2 reports offsets in code points; JS strings index in UTF-16 code units,
+  // so every astral character earlier in the file used to shift the splice by
+  // one and cut into surrounding text.
+  it('replace_text and edit splice correctly past astral characters', async () => {
+    const prefix = '# T\n\n> 🟢 a 🔺 b 📅 c\n\n';
+    const file = await writeTestFile(
+      tmpDir,
+      'emoji/rep.md',
+      `${prefix}Line with ALPHA and more.\n`,
+    );
+
+    for (const args of [
+      { caseSensitive: false, isRegex: false },
+      { caseSensitive: true, isRegex: false },
+      { caseSensitive: true, isRegex: true },
+      { caseSensitive: false, isRegex: false, wholeWord: true },
+    ]) {
+      await writeFile(file, `${prefix}Line with ALPHA and more.\n`);
+      const result = await harness.client.callTool({
+        name: 'replace_text',
+        arguments: { path: file, searchPattern: 'ALPHA', replacement: 'BETA', ...args },
+      });
+      assert.notStrictEqual(result.isError, true);
+      assert.strictEqual(
+        await readFile(file, 'utf-8'),
+        `${prefix}Line with BETA and more.\n`,
+        `replace_text with ${JSON.stringify(args)}`,
+      );
+    }
+
+    await writeFile(file, `${prefix}Line with ALPHA and more.\n`);
+    const edited = await harness.client.callTool({
+      name: 'edit',
+      arguments: {
+        path: file,
+        edits: [{ oldText: 'with ALPHA and', newText: 'with BETA and' }],
+        ignoreWhitespace: true,
+      },
+    });
+    assert.notStrictEqual(edited.isError, true);
+    assert.strictEqual(await readFile(file, 'utf-8'), `${prefix}Line with BETA and more.\n`);
+
+    // The reported column is a UTF-16 offset into the line, as `indexOf` gives.
+    const searched = await harness.client.callTool({
+      name: 'search_text',
+      arguments: { path: join(tmpDir, 'emoji'), searchPattern: 'BETA' },
+    });
+    const sc = searched._meta as { matches?: { column: number }[] };
+    assert.strictEqual(sc.matches?.[0]?.column, 'Line with '.length);
+  });
+
   it('TC-FUNC-014: find_files returns matched files via callTool', async () => {
     await writeTestFile(tmpDir, 'findme.txt', 'x');
     const result = await harness.client.callTool({

--- a/src/core/search.ts
+++ b/src/core/search.ts
@@ -78,23 +78,89 @@ export function freeRegex(regex: Regex | undefined): void {
   }
 }
 
+export interface RegexMatch {
+  /** The matched text. */
+  text: string;
+  /** Capture groups, 1-indexed in the pattern, 0-indexed here. */
+  groups: (string | undefined)[];
+  /** Named capture groups, when the pattern declares any. */
+  named: Record<string, string> | undefined;
+  /** Start offset in UTF-16 code units — usable with `String.prototype.slice`. */
+  start: number;
+  /** End offset in UTF-16 code units. */
+  end: number;
+}
+
+/** Code-point length of `text`, i.e. its UTF-16 length minus its surrogate pairs. */
+function codePointLength(text: string): number {
+  let length = 0;
+  for (let i = 0; i < text.length; i++) {
+    if ((text.charCodeAt(i) & 0xfc00) === 0xd800 && (text.charCodeAt(i + 1) & 0xfc00) === 0xdc00) {
+      i++;
+    }
+    length++;
+  }
+  return length;
+}
+
+/**
+ * Iterate a global pattern's non-overlapping matches with offsets JS can use.
+ *
+ * re2-wasm reports `index` and `lastIndex` in **code points**, while every JS
+ * string operation indexes in UTF-16 code units. The two agree only until the
+ * first astral character (most emoji), past which every offset is short by one
+ * per surrogate pair — slicing on the raw index cuts into the middle of
+ * neighbouring text. Its `lastIndex` bookkeeping is worse still: it adds the
+ * match's UTF-16 length to a code-point index, so an astral character inside a
+ * match can skip the next one. This is the single place that corrects both; no
+ * caller should read `match.index` or `regex.lastIndex` directly.
+ *
+ * Zero-length matches (e.g. `a*`) advance by one code point so they cannot loop
+ * forever. The regex is global and shared across calls, so `lastIndex` is reset
+ * on entry.
+ */
+export function* execMatches(regex: Regex, text: string): Generator<RegexMatch, undefined> {
+  regex.lastIndex = 0;
+  // Cursor into `text`, carried forward across matches: RE2 reports them in
+  // ascending order, so the walk is O(text) in total rather than per match.
+  let cursorCp = 0;
+  let cursorU16 = 0;
+  let match: RE2ExecArray | null;
+  while ((match = regex.exec(text)) !== null) {
+    while (cursorCp < match.index && cursorU16 < text.length) {
+      const isPair =
+        (text.charCodeAt(cursorU16) & 0xfc00) === 0xd800 &&
+        (text.charCodeAt(cursorU16 + 1) & 0xfc00) === 0xdc00;
+      cursorU16 += isPair ? 2 : 1;
+      cursorCp++;
+    }
+    const matched = match[0] ?? '';
+    const start = cursorU16;
+    yield {
+      text: matched,
+      groups: match.slice(1),
+      named: match.groups,
+      start,
+      end: start + matched.length,
+    };
+    // Own the advance rather than trusting the wrapper's mixed-unit arithmetic.
+    regex.lastIndex = match.index + (matched.length === 0 ? 1 : codePointLength(matched));
+  }
+}
+
 /**
  * Find non-overlapping occurrences of a global regex in a single line, reporting
- * the first match's column alongside the count. Guards zero-length matches
- * (e.g. `a*`) so they cannot loop forever.
+ * the first match's column alongside the count.
  */
 function findLineMatches(
   regex: Regex,
   line: string,
 ): { count: number; column: number } | undefined {
-  regex.lastIndex = 0;
   let count = 0;
   let column = -1;
-  let match: RE2ExecArray | null;
-  while ((match = regex.exec(line)) !== null) {
-    if (column === -1) column = match.index;
+  for (const match of execMatches(regex, line)) {
+    if (column === -1) column = match.start;
     count++;
-    if (match.index === regex.lastIndex) regex.lastIndex++; // advance past zero-length match
     if (count >= MAX_MATCHES_PER_LINE) break;
   }
   return count > 0 ? { count, column } : undefined;

--- a/src/tools/edit.ts
+++ b/src/tools/edit.ts
@@ -20,7 +20,7 @@ import {
   RequiredPath,
   singleOrBatchAccessPaths,
 } from '../core/schema.js';
-import { compileRegex, freeRegex } from '../core/search.js';
+import { compileRegex, execMatches, freeRegex } from '../core/search.js';
 import type { ResourceStore } from '../core/store.js';
 import { isTotalFailure, runOverPaths } from './batch.js';
 import { defineTool, type ToolCtx } from './define.js';
@@ -191,20 +191,15 @@ function findEditMatch(
       .replace(/[^\S\n]+/g, '[^\\S\\n]*');
     const regex = compileRegex(pattern, { caseSensitive: true });
     try {
-      // The compiled regex is global, so lastIndex may point past a previous
-      // exec — reset before searching.
-      regex.lastIndex = 0;
-      const match = regex.exec(content);
-
-      if (match === null) return undefined;
-      // RE2ExecArray types group 0 as optional. A successful match always has it;
-      // an empty one would name a zero-length span, which cannot be replaced.
-      const matched = match[0];
-      if (matched === undefined || matched.length === 0) return undefined;
+      // execMatches resets lastIndex and reports UTF-16 offsets; the raw RE2
+      // index counts code points and would splice off-by-one per emoji.
+      const { value: match } = execMatches(regex, content).next();
+      // A zero-length match names an empty span, which cannot be replaced.
+      if (match === undefined || match.text.length === 0) return undefined;
 
       return {
-        startIndex: match.index,
-        length: matched.length,
+        startIndex: match.start,
+        length: match.text.length,
       };
     } finally {
       // The compiled pattern owns wasm memory re2-wasm never reclaims on its

--- a/src/tools/replace-in-files.ts
+++ b/src/tools/replace-in-files.ts
@@ -35,7 +35,7 @@ import {
   SafeGlobPattern,
 } from '../core/schema.js';
 import type { Regex } from '../core/search.js';
-import { compileRegex, freeRegex } from '../core/search.js';
+import { compileRegex, execMatches, freeRegex } from '../core/search.js';
 import {
   DEFAULT_SEARCH_RESULTS,
   DEFAULT_SEARCH_TIMEOUT_MS,
@@ -178,8 +178,8 @@ const DOLLAR_TOKEN = /\$(\$|&|`|'|<([^>]*)>|\d{1,2})/g;
  * `Invalid replacement string` on any `$` not followed by a substitution it
  * recognises (so a replacement of `$100` or a trailing `$` fails outright,
  * where `RegExp` inserts the `$` literally), and it renders an out-of-range
- * `$5` as `$4`. Passing a function to `String.replace` disables RE2's handling
- * entirely, which leaves this the single owner of the syntax.
+ * `$5` as `$4`. The matcher splices matches itself, so this is the single owner
+ * of the syntax.
  */
 function expandDollarTokens(
   template: string,
@@ -222,37 +222,33 @@ function createRegexReplacementMatcher(
       return regex.test(buffer.toString('utf-8'));
     },
     replace(content: string, replacement: string): { content: string; matchCount: number } {
-      regex.lastIndex = 0;
+      // Splicing by hand rather than through `String.replace(regex, …)`: RE2's
+      // own replacer indexes the JS string with the code-point offsets it
+      // reports, which lands the replacement short by one per astral character
+      // (most emoji) earlier in the file. execMatches reports UTF-16 offsets.
       let matchCount = 0;
-      // Only isRegex=true opts into $1/$& substitution. A literal search reaches
-      // this matcher too (case-insensitive and wholeWord both need a regex), and
-      // there the replacement must be inserted verbatim.
-      if (!expandReplacement) {
-        const updated = content.replace(regex, () => {
-          matchCount++;
-          return replacement;
-        });
-        return { content: updated, matchCount };
-      }
-      const updated = content.replace(regex, (match: string, ...rest: unknown[]): string => {
+      let updated = '';
+      let cursor = 0;
+      for (const match of execMatches(regex, content)) {
         matchCount++;
-        // In ECMAScript/RE2, trailing arguments are [offset, input] or [offset, input, namedGroups].
-        const named =
-          rest.length >= 3 && typeof rest[rest.length - 3] === 'number'
-            ? (rest.pop() as Record<string, string> | undefined)
-            : undefined;
-        const input = rest.pop() as string;
-        const offset = rest.pop() as number;
-        return expandDollarTokens(
-          replacement,
-          match,
-          rest as (string | undefined)[],
-          offset,
-          input,
-          named,
-        );
-      });
-      return { content: updated, matchCount };
+        // Only isRegex=true opts into $1/$& substitution. A literal search
+        // reaches this matcher too (case-insensitive and wholeWord both need a
+        // regex), and there the replacement must be inserted verbatim.
+        updated +=
+          content.slice(cursor, match.start) +
+          (expandReplacement
+            ? expandDollarTokens(
+                replacement,
+                match.text,
+                match.groups,
+                match.start,
+                content,
+                match.named,
+              )
+            : replacement);
+        cursor = match.end;
+      }
+      return { content: updated + content.slice(cursor), matchCount };
     },
     dispose(): void {
       freeRegex(regex);


### PR DESCRIPTION
Fixes #24.

## Cause

`@adguard/re2-wasm` reports `exec().index`, `lastIndex`, and the replace-callback `offset` in **code points** — not UTF-8 bytes, as the report guessed. Every JS string operation indexes in UTF-16 code units. The two agree only until the first astral character (most emoji), past which every offset is short by one per surrogate pair:

```
'a🟢b🔺c ALPHA'
 ^     ^     ^
 cp 0  cp 3  cp 6    <- RE2 reports index 6
 u16 0 u16 4 u16 8   <- String.slice needs 8
```

On the reported file, `exec` gives index 58 where `indexOf` gives 61 — off by exactly the surrogate-pair count. RE2's own `[Symbol.replace]` then splices with `input.substring(match.index, …)`, so `replace_text` wrote the replacement three positions early, cutting into surrounding words and dropping characters while reporting success and a correct match count.

There is a second, smaller defect in the same wrapper: `lastIndex = match.index + match.match.length` adds a UTF-16 length to a code-point index, so an astral character *inside* a match can make the scan skip the next one.

## Blast radius

Two callers beyond the one reported shared the root cause:

| Site | Symptom |
| --- | --- |
| `src/tools/replace-in-files.ts` | Reported bug — corrupt splice |
| `src/tools/edit.ts` | Same corruption under `ignoreWhitespace: true` |
| `src/core/search.ts` | `search_text` reports a wrong `column` |

`edit` looked unaffected in the report only because `ignoreWhitespace` defaults to `false`; that path uses `indexOf`, like the case-sensitive literal matcher that also escaped.

## Fix

One offset-correcting generator, `execMatches`, in `src/core/search.ts` — the single place that converts an offset. It walks a code-point/UTF-16 cursor forward across matches (O(n) over the text in total, not per match) and sets `lastIndex` itself, bypassing the wrapper's mixed-unit arithmetic. All three callers now read `match.start` / `match.end`; none touches `match.index` or `regex.lastIndex`.

Dropping `String.replace(re2, fn)` in favour of an explicit splice loop also fixes ``$` `` and `$'` in a replacement template, which were being sliced at the same bad offset.

## Verification

New test covers the reporter's fixture: `replace_text` across all four flag combinations (default, `caseSensitive`, `caseSensitive + isRegex`, `wholeWord`), `edit` with `ignoreWhitespace: true`, and the `search_text` column. `node scripts/tasks.mjs` is green — 277 tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Gh7gPBebnzu89yw64N2jpn
