### PR TITLE
refactor: land six architecture-audit findings

### DIFF
--- a/README.md
+++ b/README.md
@@ -259,7 +259,6 @@ All tools are scoped to the configured roots. Call `list_roots` first to discove
 ```text
 filesystem-mcp/
 ├── __tests__/        Test suites
-├── scripts/          Build and task utilities
 ├── src/
 │   ├── core/         Path guarding, filesystem abstraction, concurrency, observability
 │   ├── tools/        Tool definitions and registration
@@ -280,7 +279,7 @@ the narrow dependency contract it consumes.
 | `src/core/path.ts`    | `PathGuard` — validates every path against allowed roots       |
 | `src/core/fs.ts`      | `GuardedFileSystem` — guarded filesystem facade                |
 | `src/tools/define.ts` | Tool registration and execution framework                      |
-| `src/tools/batch.ts`  | Batch helpers (runOverPaths, normalizeBatchItems)              |
+| `src/tools/batch.ts`  | Batch helpers (runOverPaths, isTotalFailure)                   |
 | `src/server.ts`       | Builds shared dependencies and invokes the three registrars    |
 | `src/transport.ts`    | Owns stdio and Streamable HTTP setup around the server factory |
 

--- a/__tests__/core-fs.test.ts
+++ b/__tests__/core-fs.test.ts
@@ -7,6 +7,7 @@ import { ErrorCode, isFsError } from '../src/core/errors.js';
 import { GuardedFileSystem } from '../src/core/fs.js';
 import { normalizePath } from '../src/core/path-utils.js';
 import { searchContent, searchFiles } from '../src/core/search.js';
+import { getDefaultReadManyMaxTotalSize } from '../src/core/util.js';
 import type { FilesystemServerContext } from '../src/server.js';
 import {
   cleanupTestRoot,
@@ -200,11 +201,11 @@ describe('Core Filesystem (GuardedFileSystem + core search) Tests', () => {
 
       const searchDir = join(tmpDir, 'search_dir');
 
-      const tsResults = await searchFiles(searchDir, '**/*.ts', [], {}, ctx.pathGuard);
+      const tsResults = await searchFiles(searchDir, '**/*.ts', {}, ctx.pathGuard);
       assert.strictEqual(tsResults.results.length, 3);
       assert.ok(tsResults.results.every((r) => r.path.endsWith('.ts')));
 
-      const txtResults = await searchFiles(searchDir, '**/*.txt', [], {}, ctx.pathGuard);
+      const txtResults = await searchFiles(searchDir, '**/*.txt', {}, ctx.pathGuard);
       assert.strictEqual(txtResults.results.length, 2);
       assert.ok(txtResults.results.every((r) => r.path.endsWith('.txt')));
     });
@@ -214,13 +215,13 @@ describe('Core Filesystem (GuardedFileSystem + core search) Tests', () => {
       await writeTestFile(tmpDir, 'sort_dir/aaa/omega.ts', '// o');
 
       const sortDir = join(tmpDir, 'sort_dir');
-      const byName = await searchFiles(sortDir, '**/*.ts', [], { sortBy: 'name' }, ctx.pathGuard);
+      const byName = await searchFiles(sortDir, '**/*.ts', { sortBy: 'name' }, ctx.pathGuard);
       assert.deepStrictEqual(
         byName.results.map((r) => basename(r.path)),
         ['alpha.ts', 'omega.ts'],
       );
 
-      const byPath = await searchFiles(sortDir, '**/*.ts', [], {}, ctx.pathGuard);
+      const byPath = await searchFiles(sortDir, '**/*.ts', {}, ctx.pathGuard);
       assert.deepStrictEqual(
         byPath.results.map((r) => basename(r.path)),
         ['omega.ts', 'alpha.ts'],
@@ -287,6 +288,51 @@ describe('Core Filesystem (GuardedFileSystem + core search) Tests', () => {
           return true;
         },
       );
+    });
+  });
+
+  describe('Invalid setting warnings (TC-FUNC-019b)', () => {
+    it('TC-FUNC-019b: a rejected numeric setting warns once and is not gated by --log-level', () => {
+      const priorLevel = process.env['FS_LOG_LEVEL'];
+      const priorBytes = process.env['FS_MAX_READ_MANY_BYTES'];
+      const realError = console.error;
+      const collected: string[] = [];
+
+      process.env['FS_LOG_LEVEL'] = 'error';
+      process.env['FS_MAX_READ_MANY_BYTES'] = 'not-a-number';
+      console.error = (...args: unknown[]) => {
+        collected.push(args.map(String).join(' '));
+      };
+
+      try {
+        const first = getDefaultReadManyMaxTotalSize();
+        const second = getDefaultReadManyMaxTotalSize();
+
+        assert.strictEqual(first, 512 * 1024, 'falls back to the documented default');
+        assert.strictEqual(second, first);
+
+        const warnings = collected.filter((line) =>
+          line.includes('Invalid FS_MAX_READ_MANY_BYTES value'),
+        );
+        // Once per (setting, value), not once per call — and it reaches stderr
+        // despite FS_LOG_LEVEL=error, which used to suppress this one warning
+        // while leaving FS_ALLOW_SENSITIVE and FS_LOG_LEVEL typos visible.
+        assert.strictEqual(
+          warnings.length,
+          1,
+          `expected one warning, got ${JSON.stringify(collected)}`,
+        );
+        assert.match(
+          warnings[0] ?? '',
+          /^\[warning\] Invalid FS_MAX_READ_MANY_BYTES value: not-a-number \(must be 10240-104857600\)\. Using default: 524288$/,
+        );
+      } finally {
+        console.error = realError;
+        if (priorLevel === undefined) delete process.env['FS_LOG_LEVEL'];
+        else process.env['FS_LOG_LEVEL'] = priorLevel;
+        if (priorBytes === undefined) delete process.env['FS_MAX_READ_MANY_BYTES'];
+        else process.env['FS_MAX_READ_MANY_BYTES'] = priorBytes;
+      }
     });
   });
 });

--- a/__tests__/resources.test.ts
+++ b/__tests__/resources.test.ts
@@ -62,6 +62,7 @@ describe('MCP Resources', () => {
       assert.match(constraints, /sensitive_paths:/);
       assert.match(constraints, /enforced_limits:/);
       assert.match(constraints, /ephemeral_results:/);
+      assert.match(constraints, /pagination: nextCursor appears in the result text and in _meta,/);
 
       // Verify error recovery content
       const errorRecovery = requiredSection(sections, 'error_recovery');

--- a/__tests__/tools.test.ts
+++ b/__tests__/tools.test.ts
@@ -731,6 +731,54 @@ describe('P0 Functional Tests - Tools (MCP Client)', () => {
     assert.strictEqual(s2.resourceUri, undefined, 'later pages never carry the URI');
   });
 
+  it('TC-FUNC-075b: list prunes an ignored directory and everything under it', async () => {
+    const sub = join(tmpDir, 'gitignore_walk_dir');
+    // Nested one level on purpose: fs.glob's function `exclude` drops a
+    // rejected entry at the top level but not below it, so a top-level fixture
+    // passes even when the walk leaks the ignored directory itself.
+    await mkdir(join(sub, 'a', 'skipme', 'deep'), { recursive: true });
+    await writeFile(join(sub, '.gitignore'), 'skipme/\n');
+    await writeFile(join(sub, 'kept.txt'), 'k');
+    await writeFile(join(sub, 'a', 'skipme', 'deep', 'buried.txt'), 'b');
+
+    // maxDepth must reach the nested file: the tool's default is 1, top-level only.
+    const pruned = await harness.client.callTool({
+      name: 'list',
+      arguments: { path: sub, maxDepth: 4 },
+    });
+    const prunedText = firstTextBlock(pruned).text ?? '';
+    assert.match(prunedText, /kept\.txt/);
+    // The directory AND its children stay out: the walk prunes, it does not
+    // enumerate then filter, so `buried.txt` is never visited.
+    assert.doesNotMatch(prunedText, /skipme/);
+    assert.doesNotMatch(prunedText, /buried\.txt/);
+
+    const all = await harness.client.callTool({
+      name: 'list',
+      arguments: { path: sub, maxDepth: 4, includeIgnored: true },
+    });
+    const allText = firstTextBlock(all).text ?? '';
+    assert.match(allText, /kept\.txt/);
+    assert.match(allText, /buried\.txt/);
+  });
+
+  it('TC-FUNC-075c: find_files drops a gitignored file below the top level', async () => {
+    const sub = join(tmpDir, 'gitignore_file_dir');
+    await mkdir(join(sub, 'nested'), { recursive: true });
+    await writeFile(join(sub, '.gitignore'), '*.log\n');
+    await writeFile(join(sub, 'nested', 'keep.txt'), 'k');
+    await writeFile(join(sub, 'nested', 'drop.log'), 'd');
+
+    const result = await harness.client.callTool({
+      name: 'find_files',
+      arguments: { path: sub, pattern: '**/*' },
+    });
+    const text = firstTextBlock(result).text ?? '';
+    assert.match(text, /keep\.txt/);
+    // A nested match the exclude predicate rejects must not survive the walk.
+    assert.doesNotMatch(text, /drop\.log/);
+  });
+
   it('TC-FUNC-075: list text carries nextCursor', async () => {
     const sub = join(tmpDir, 'cursor_text_dir');
     await mkdir(sub, { recursive: true });
@@ -741,8 +789,10 @@ describe('P0 Functional Tests - Tools (MCP Client)', () => {
       arguments: { path: sub, maxEntries: 2 },
     });
     const firstText = firstTextBlock(first).text ?? '';
-    const match = /^nextCursor: (\S+)$/m.exec(firstText);
-    assert.ok(match, `first page text should carry a nextCursor line: ${firstText}`);
+    const match = /^\/\/ showing 1-2 of 4 entries\. Next page: list \{"cursor":"([^"]+)"\}$/m.exec(
+      firstText,
+    );
+    assert.ok(match, `first page text should carry its position and cursor: ${firstText}`);
     const cursor = match[1];
     // The model passes back verbatim what it read, so the two must agree.
     assert.strictEqual(cursor, (first._meta as { nextCursor?: string }).nextCursor);
@@ -752,7 +802,10 @@ describe('P0 Functional Tests - Tools (MCP Client)', () => {
       arguments: { path: sub, maxEntries: 2, cursor },
     });
     const secondText = firstTextBlock(second).text ?? '';
-    assert.ok(!/^nextCursor: /m.test(secondText), 'last page advertises no next page');
+    // The last page carries no cursor and still owes its position, or a
+    // two-row tail reads as the whole answer.
+    assert.match(secondText, /^\/\/ showing 3-4 of 4 entries\.$/m);
+    assert.doesNotMatch(secondText, /Next page/);
   });
 
   it('TC-FUNC-063b: list pages are stable and query-bound', async () => {

--- a/docs/plan/2026-09-10-arch-audit-six/arch-audit-six.plan-hunt.md
+++ b/docs/plan/2026-09-10-arch-audit-six/arch-audit-six.plan-hunt.md
@@ -1,0 +1,92 @@
+# Plan hunt: arch-audit-six
+
+Adversarial pass over [`arch-audit-six.plan.md`](arch-audit-six.plan.md),
+2026-09-10, against commit `8bf08572`.
+
+Six steps checked against all five dead-step tells. Every path and symbol the
+plan cites was verified against the repo. Three candidates reached a blind
+refuter; one came back confirmed.
+
+**Verdict: one confirmed defect. The plan does not go to run-plan until it is
+fixed.**
+
+## Confirmed
+
+### 1. Step 4, item 5 — an edit no gate can see
+
+[Step 4](arch-audit-six.plan.md) item 5 instructs:
+
+> Fix the claim this makes false at [`instructions.ts:71`](../../../src/instructions.ts#L71):
+> all three paged tools now carry the cursor in the trailer text *and* in
+> `_meta`, so remove the `the text (list) or _meta (find_files, search_text)`
+> split and say it plainly once.
+
+**Tell:** step with no gate.
+
+**Trigger:** the executor edits [`src/instructions.ts:71`](../../../src/instructions.ts#L71),
+or forgets to, then runs step 4's Verify.
+
+**Impact:** the string ships to every model client as part of the server's
+`instructions`. Nothing distinguishes an unedited line 71, a correct rewrite,
+and an invented one.
+
+**Ruled out**, independently:
+
+- Step 4's Verify is `npm run check:static && npm test`. `check:static` is
+  `npm run build && npm run type-check && npm run type-check:test && eslint . &&
+  prettier --check . && knip` ([`package.json`](../../../package.json)) — none of
+  which reads the meaning of a string literal.
+- The tests that touch `buildSectionsRecord` compare the module's output to
+  itself. [`__tests__/resources.test.ts:157`](../../../__tests__/resources.test.ts#L157)
+  asserts `instructionsContent.text` equals `rendered`, both derived from the
+  same call; [`__tests__/prompts.test.ts:74`](../../../__tests__/prompts.test.ts#L74)
+  does the same with `assert.equal(textContent.text, fullInstructions);`. Any
+  rewrite of line 71 passes identically. So does no rewrite at all.
+- The one content-level test stops short. TC-FUNC-055 at
+  [`__tests__/resources.test.ts:61-64`](../../../__tests__/resources.test.ts#L61-L64)
+  enumerates the constraints keys from `allowed_roots:` through
+  `ephemeral_results:` and moves on to error recovery at line 66 — it never
+  reaches `pagination:`. `grep -rn "pagination:" __tests__/ src/` returns exactly
+  one hit: `src/instructions.ts:71`, with no test hit.
+- The plan's own Done checklist greps for `excludePatterns|respectGitignore`,
+  `FilesystemServerContext`, the seven renamed constants, and `name: '`. None
+  names this line. `git status` gives no signal either: `src/instructions.ts` is
+  legitimately modified by step 5's constant renames regardless.
+- Step 5 cannot force the executor past it. Line 71 spells the wire names as
+  literals — `find_files, search_text` — not through the `SEARCH_FILES` /
+  `SEARCH_CONTENT` constants that step 5 renames, so the rename sweep does not
+  touch it.
+
+**What the fix has to supply** — this is the plan author's call, not the
+hunter's:
+
+1. The exact replacement sentence, quoted in the step, so there is nothing to
+   author at execution time.
+2. A check that fails when it is missing. The cheapest one that matches the
+   repo's existing shape is an assertion in the TC-FUNC-055 chain at
+   [`resources.test.ts:61-64`](../../../__tests__/resources.test.ts#L61-L64),
+   which already walks the constraints keys and would only need
+   `pagination:` added to the walk — and, unlike the tautological tests, would
+   actually read the shipped text.
+3. A corresponding line in the plan's Done checklist.
+
+## Suspected
+
+None.
+
+## Coverage
+
+- Steps hunted: 1 through 6, all six.
+- Candidates raised and refuted: 3. Two were killed by the refuter against the
+  repo and are not reported here.
+- Refuters: blind, one dispatch per candidate, no in-thread fallback used.
+- Checks run during the hunt that dismissed a tell before it became a candidate:
+  `searchFiles` caller enumeration, `new`/`instanceof FilesystemServerContext`
+  across `src` and `__tests__`, `handleList` return-type and return-object line
+  ranges, `scripts/` occurrence count in `README.md`, and `respectGitignore`
+  occurrence set.
+
+## Route
+
+Back to [write-plan](arch-audit-six.plan.md) for finding 1, then straight to
+run-plan. Steps 1, 2, 3, 5 and 6 are clean and need no rework.

--- a/docs/plan/2026-09-10-arch-audit-six/arch-audit-six.plan.md
+++ b/docs/plan/2026-09-10-arch-audit-six/arch-audit-six.plan.md
@@ -1,0 +1,925 @@
+# Plan: Land the six architecture-audit findings
+
+> **Executor rules**: work the steps in order. Run every Verify command and
+> confirm its expected result before moving on. On any STOP condition, stop and
+> report the condition, the step, and the evidence.
+>
+> **Written against** commit `8bf08572`, 2026-09-10.
+> **Drift check (run first)**:
+> `git diff --stat 8bf08572..HEAD -- src/ __tests__/ README.md`
+> Its file list is what narrows the excerpt match: compare
+> [Current state](#current-state) against the live code for every file it flags.
+> A mismatch is a [STOP](#stop) condition.
+
+## Goal
+
+An architecture audit of this repo produced six findings that clear its bar.
+Four are ownership defects — a rule the domain has that no module owns, so it
+is re-derived at three or four call sites and the copies have already drifted
+apart. One is a user-visible output bug: a truncated `list` response reads as a
+complete one. One is a class that exists to hold two fields only its own
+`dispose` reads.
+
+Concrete cost today: a `list` caller cannot tell page 2 of 5 from the whole
+answer; a typo in `FS_MAX_FILE_SIZE` is silent at `--log-level=error` while the
+same typo in `FS_ALLOW_SENSITIVE` prints; `list` walks and individually re-tests
+every file under a gitignored directory that the three sibling tools prune at
+walk time.
+
+When this lands: one owner for each of those rules, one field fewer on two core
+option types, one class fewer, and every tool findable by the name it answers
+to on the wire.
+
+Requirements covered: none — this is a set of fixes and refactors.
+
+## Current state
+
+Every excerpt below was re-opened at its cited line at `8bf08572`.
+
+### The build
+
+- `npm run check:static` exits 0 at `8bf08572`.
+- `npm test` reports `tests 277 / pass 277 / fail 0`.
+- Working tree is clean; branch is `main`.
+
+### Step 1 — the server context class
+
+[`src/server.ts:31-60`](../../../src/server.ts#L31-L60) — the whole class:
+
+```ts
+export class FilesystemServerContext {
+  public readonly mcp: McpServer;
+  public readonly pathGuard: PathGuard;
+  public readonly pages: PageSnapshotStore;
+  /** False when the store is shared across instances and outlives this one. */
+  private readonly ownsPages: boolean;
+  private readonly resourceDisposable?: { dispose(): void } | undefined;
+  private cleanedUp = false;
+
+  constructor(
+    mcp: McpServer,
+    pathGuard: PathGuard,
+    pages: PageSnapshotStore,
+    ownsPages: boolean,
+    resourceDisposable?: { dispose(): void },
+  ) {
+    this.mcp = mcp;
+    this.pathGuard = pathGuard;
+    this.pages = pages;
+    this.ownsPages = ownsPages;
+    this.resourceDisposable = resourceDisposable;
+  }
+
+  disposeRuntimeState(): void {
+    if (this.cleanedUp) return;
+    this.cleanedUp = true;
+    if (this.ownsPages) this.pages.clear();
+    this.resourceDisposable?.dispose();
+  }
+}
+```
+
+[`src/server.ts:191-201`](../../../src/server.ts#L191-L201) — its only construction
+site:
+
+```ts
+  const resourceDisposable = registerResources(deps);
+  registerPrompts(deps);
+  registerTools(deps);
+
+  return new FilesystemServerContext(
+    server,
+    pathGuard,
+    pageStore,
+    extraDeps?.pageStore === undefined,
+    resourceDisposable,
+  );
+```
+
+`.pages` has no reader anywhere outside the class — `grep -rn '\.pages\b' src
+__tests__` returns only `server.ts:49` and `server.ts:57`. External readers use
+`.mcp`, `.pathGuard`, and `.disposeRuntimeState()` only.
+
+[`src/resources.ts:425`](../../../src/resources.ts#L425) declares
+`registerResources` as returning `{ dispose(): void }` — **non-nullable**. This
+is load-bearing for step 1: see its STOP note.
+
+### Step 2 — the invalid-setting warning, written three times
+
+[`src/core/util.ts:9-25`](../../../src/core/util.ts#L9-L25):
+
+```ts
+const loggedWarns = new Set<string>();
+
+function logInvalidEnvValue(
+  envVar: string,
+  value: string,
+  expected: string,
+  defaultValue: number | boolean,
+): void {
+  const key = `${envVar}:${value}:${expected}`;
+  if (loggedWarns.has(key)) {
+    return;
+  }
+  loggedWarns.add(key);
+  Logger.warn(
+    `Invalid ${envVar} value: ${value} (must be ${expected}). Using default: ${String(defaultValue)}`,
+  );
+}
+```
+
+Its only caller is [`util.ts:57`](../../../src/core/util.ts#L57), inside
+`parseIntSetting`. `Logger` is imported at
+[`util.ts:4`](../../../src/core/util.ts#L4) and used at
+[`util.ts:22`](../../../src/core/util.ts#L22) **and nowhere else in the file**.
+
+[`src/core/primitives.ts:26,37-46`](../../../src/core/primitives.ts#L37-L46):
+
+```ts
+const warnedFlagValues = new Set<string>();
+// ...
+  if (name && trimmed !== '' && trimmed !== 'false' && trimmed !== '0') {
+    const key = `${name}:${trimmed}`;
+    if (!warnedFlagValues.has(key)) {
+      warnedFlagValues.add(key);
+      // console.error, not Logger: this module stays dependency-free to avoid
+      // import cycles (same precedent as parseLogLevel in observability.ts).
+      console.error(
+        `[warning] Invalid ${name} value: ${value} (must be "true" or "1"). Using default: false`,
+      );
+    }
+  }
+```
+
+[`src/core/observability.ts:27-30`](../../../src/core/observability.ts#L27-L30):
+
+```ts
+  console.error(
+    `[warning] Invalid FS_LOG_LEVEL value: ${raw} (must be ${LEVEL_ORDER.join('|')}). Using default: info`,
+  );
+  return 'info';
+```
+
+The file header at
+[`primitives.ts:3-6`](../../../src/core/primitives.ts#L3-L6) is the record that
+picks the destination:
+
+> `Minimal shared primitives with no intra-package dependencies.`
+> `Kept separate to avoid import cycles between observability.ts and util.ts.`
+
+`primitives.ts` imports only `node:path`, so a call into it from
+`observability.ts` creates no cycle.
+
+The three disagree on **behavior**, not only on code. `Logger.warn` routes
+through [`observability.ts:59-63`](../../../src/core/observability.ts#L59-L63)
+and is gated by `isLevelEnabled`, so `util.ts`'s copy is suppressed at
+`--log-level=error`; the other two write to stderr unconditionally.
+
+`Logger.warn` prepends `[warning] ` itself
+([`observability.ts:61-62`](../../../src/core/observability.ts#L61-L62)), which
+is why the other two type that prefix by hand. Moving `util.ts`'s copy to
+`console.error` therefore leaves its emitted text byte-identical.
+
+[`src/core/config.ts:36`](../../../src/core/config.ts#L36) — needed by the new
+test: `export const cli: CliOverrides = {}`, written once by `cli.ts` at
+startup, so `cli.logLevel` is `undefined` under `node --test` and
+`getLogLevel()` falls through to `process.env['FS_LOG_LEVEL']`.
+
+### Step 3 — `includeIgnored` translated in four tools
+
+The flag's schema has an owner —
+[`src/core/schema.ts:193`](../../../src/core/schema.ts#L193),
+`includeIgnoredField()`. Its meaning does not. Every call site passes the same
+pair, and `excludePatterns` never carries a value other than
+`DEFAULT_EXCLUDE_PATTERNS` or `[]`:
+
+- [`search-content.ts:193,198`](../../../src/tools/search-content.ts#L193-L198)
+- [`replace-in-files.ts:503,505`](../../../src/tools/replace-in-files.ts#L503-L505)
+- [`search-files.ts:147,152`](../../../src/tools/search-files.ts#L147-L152)
+- [`list.ts:92`](../../../src/tools/list.ts#L92) — passes `excludePatterns` but
+  **never** `respectGitignore`
+
+[`src/core/glob.ts:194-203`](../../../src/core/glob.ts#L194-L203):
+
+```ts
+export interface GlobEntriesOptions {
+  cwd: string;
+  pattern: string;
+  excludePatterns?: readonly string[];
+  includeHidden?: boolean;
+  baseNameMatch?: boolean;
+  maxDepth?: number;
+  onlyFiles?: boolean;
+  suppressErrors?: boolean;
+  respectGitignore?: boolean;
+}
+```
+
+[`glob.ts:306`](../../../src/core/glob.ts#L306) inside `normalizeGlobOptions`:
+
+```ts
+    exclude: (options.excludePatterns ?? []).map(toPosixPath),
+```
+
+[`glob.ts:409-414`](../../../src/core/glob.ts#L409-L414) inside `globEntries`:
+
+```ts
+  let gitignoreMatcher: GitignoreManager | null = null;
+  if (options.respectGitignore) {
+    gitignoreMatcher = await loadRootGitignore(options.cwd);
+  }
+```
+
+`createExcludeFilter` ([`glob.ts:344-374`](../../../src/core/glob.ts#L344-L374))
+is handed to Node's `fsGlob` as its `exclude` callback
+([`glob.ts:398`](../../../src/core/glob.ts#L398)), so it filters **at walk time
+and prunes ignored directories**.
+
+`list` does the same predicate in the wrong position — after enumeration:
+
+[`list.ts:79-81`](../../../src/tools/list.ts#L79-L81):
+
+```ts
+  const gitignoreMatcher = options.includeIgnored
+    ? null
+    : await loadRootGitignore(rootPath, options.signal);
+```
+
+[`list.ts:110-112`](../../../src/tools/list.ts#L110-L112):
+
+```ts
+    if (gitignoreMatcher?.isIgnored(relPath, isDir)) {
+      continue;
+    }
+```
+
+> **This is the one real behavior change in step 3.** Children of a gitignored
+> directory are never enumerated on the glob path, but are walked and
+> individually re-tested on `list`'s path. Git semantics say a path under an
+> ignored directory cannot be re-included, so the two agree on the final set —
+> but only a test proves it here.
+
+[`src/core/search.ts:169-176`](../../../src/core/search.ts#L169-L176) and
+[`search.ts:343`](../../../src/core/search.ts#L343) carry the same pair; the
+latter as a **positional** parameter:
+
+```ts
+export async function searchFiles(
+  directory: string,
+  pattern: string,
+  excludePatterns: string[],
+  options: { /* ... respectGitignore?: boolean; ... */ },
+  pathGuard: PathGuard,
+)
+```
+
+Its four test call sites pass `[]` for that positional —
+[`core-fs.test.ts:203`](../../../__tests__/core-fs.test.ts#L203),
+[`:207`](../../../__tests__/core-fs.test.ts#L207),
+[`:217`](../../../__tests__/core-fs.test.ts#L217),
+[`:223`](../../../__tests__/core-fs.test.ts#L223):
+
+```ts
+      const tsResults = await searchFiles(searchDir, '**/*.ts', [], {}, ctx.pathGuard);
+```
+
+After this step `DEFAULT_EXCLUDE_PATTERNS`
+([`glob.ts:425`](../../../src/core/glob.ts#L425)) and `loadRootGitignore`
+([`glob.ts:172`](../../../src/core/glob.ts#L172)) lose every caller outside
+`glob.ts`.
+
+### Step 4 — `list` hand-rolls its trailer
+
+[`src/core/fmt.ts:114-116`](../../../src/core/fmt.ts#L114-L116) — the stated
+invariant on the owner:
+
+```ts
+  const lines: string[] = [];
+  // Position is owed on every page of a split set, including the last one —
+  // which has no cursor and would otherwise read as the whole answer.
+  if (p.offset > 0 || p.total > p.shown) {
+```
+
+`pageTrailer` prefixes its own `\n\n`
+([`fmt.ts:132`](../../../src/core/fmt.ts#L132)) and emits nothing at all for a
+complete single page.
+
+[`list.ts:358-375`](../../../src/tools/list.ts#L358-L375) — the hand-rolled
+version, which emits a line only when `nextCursor` or `resourceUri` exists:
+
+```ts
+    const { structured, markdown, link } = await handleList(args, ctx);
+    // ...
+    const trailer: string[] = [];
+    if (structured.nextCursor !== undefined) {
+      trailer.push(`nextCursor: ${structured.nextCursor}`);
+    }
+    if (structured.resourceUri !== undefined) {
+      trailer.push(
+        `${String(structured.entryCount)} of ${String(structured.totalEntries)} entries shown; full tree at ${structured.resourceUri}`,
+      );
+    }
+    return {
+      structured,
+      text: trailer.length > 0 ? `${markdown}\n\n${trailer.join('\n')}` : markdown,
+      ...(link ? { resources: [link] } : {}),
+    };
+```
+
+`nextCursor` is `undefined` on the last page
+([`cursor.ts:27-30`](../../../src/core/cursor.ts#L27-L30)) and `resourceUri` is
+first-page-only ([`cursor.ts:81-85`](../../../src/core/cursor.ts#L81-L85)), so
+the last page of a split listing ships a bare tree.
+
+The two sibling paged tools do it right, and both are the exemplar to imitate —
+[`search-files.ts:228-238`](../../../src/tools/search-files.ts#L228-L238):
+
+```ts
+    const text =
+      body +
+      pageTrailer({
+        offset,
+        shown: structured.results.length,
+        total,
+        noun: 'files',
+        tool: 'find_files',
+        nextCursor: structured.nextCursor,
+        stoppedReason: structured.stoppedReason,
+      });
+```
+
+They get `offset` by returning it from their handler —
+[`search-files.ts:191`](../../../src/tools/search-files.ts#L191),
+`offset: paged.offset`. `paginate` supplies it
+([`cursor.ts:48-55`](../../../src/core/cursor.ts#L48-L55)); `handleList`
+receives `paged` and currently throws `offset` away
+([`list.ts:325-329`](../../../src/tools/list.ts#L325-L329)).
+
+> `list.ts` does **not** import `../core/fmt.js` today. Its import block ends at
+> [`list.ts:31`](../../../src/tools/list.ts#L31). Add a new import line; do not
+> look for an existing one to extend.
+
+[`__tests__/tools.test.ts:734-756`](../../../__tests__/tools.test.ts#L734-L756)
+— TC-FUNC-075 pins the **old** format and therefore breaks:
+
+```ts
+    const match = /^nextCursor: (\S+)$/m.exec(firstText);
+    assert.ok(match, `first page text should carry a nextCursor line: ${firstText}`);
+    const cursor = match[1];
+    // ...
+    assert.ok(!/^nextCursor: /m.test(secondText), 'last page advertises no next page');
+```
+
+[`__tests__/tools.test.ts:1457-1458`](../../../__tests__/tools.test.ts#L1457-L1458)
+is the shape to mirror — the executable record of the same rule for
+`search_text`:
+
+```ts
+    assert.match(lastText, /^\/\/ showing 9-9 of 9 matches\.$/m);
+    assert.doesNotMatch(lastText, /Next page/);
+```
+
+[`src/instructions.ts:71`](../../../src/instructions.ts#L71) ships a claim to
+the model that this step makes false:
+
+```
+'pagination: nextCursor appears in the text (list) or _meta (find_files, search_text) and is backed by a snapshot on the same ~60s clock. ...'
+```
+
+Nothing in `__tests__` asserts on the string `full tree at` or
+`entries shown` — verified by grep, only `list.ts:368` matches.
+
+### Step 5 — three names per tool
+
+The wire name is the contract: documented in backticks at
+[`README.md:214-241`](../../../README.md#L214-L241) and called by name in the
+tests. Seven of thirteen tools disagree with it in their filename, their export
+constant, or both:
+
+| Wire name (contract) | File today             | Constant today             |
+| :------------------- | :--------------------- | :------------------------- |
+| `search_text`        | `search-content.ts`    | `SEARCH_CONTENT`           |
+| `find_files`         | `search-files.ts`      | `SEARCH_FILES`             |
+| `replace_text`       | `replace-in-files.ts`  | `SEARCH_AND_REPLACE`       |
+| `list_roots`         | `roots.ts`             | `LIST_ALLOWED_DIRECTORIES` |
+| `delete`             | `delete-file.ts`       | `DELETE_FILE`              |
+| `stat`               | `stat.ts` (matches)    | `GET_FILE_INFO`            |
+| `read`               | `read.ts` (matches)    | `READ_FILE`                |
+
+[`src/tools/index.ts:6-19`](../../../src/tools/index.ts#L6-L19) is the only
+module that imports these files, and
+[`src/instructions.ts:6-14`](../../../src/instructions.ts#L6-L14) is the only
+other module that imports the constants. Verified: no test imports any of these
+files by path.
+
+`src/tools/index.ts` re-exports six of the seven for `instructions.ts`
+([`index.ts:51`](../../../src/tools/index.ts#L51)), under a comment stating that
+this module is the one owner of the inventory.
+
+### Step 6 — the README structure table
+
+[`README.md:257-286`](../../../README.md#L257-L286). Two rows describe a repo
+that no longer exists:
+
+```text
+├── scripts/          Build and task utilities
+```
+
+`ls scripts` → `No such file or directory`. The directory was deleted; its 67
+commits are all in the past.
+
+```text
+| `src/tools/batch.ts`  | Batch helpers (runOverPaths, normalizeBatchItems)              |
+```
+
+[`batch.ts:20`](../../../src/tools/batch.ts#L20) declares
+`normalizeBatchItems` as a **private** function. The file's exports are
+`PerPathResult`, `BatchResult`, `runOverPaths`, `isTotalFailure`
+([`batch.ts:6,8,33,98`](../../../src/tools/batch.ts#L6-L98)).
+
+The rest of that section is correct and must not be touched — in particular the
+declared gradient at [`README.md:274-276`](../../../README.md#L274-L276)
+("Runtime composition flows from `src/index.ts` to `src/transport.ts`, then to
+`src/server.ts`, the registrars, and finally `src/core/`") matches the code.
+
+### Conventions to match
+
+- **Error/format helpers live in `core/`, tools call them.** Exemplar:
+  [`search-files.ts:228-238`](../../../src/tools/search-files.ts#L228-L238)
+  calling `pageTrailer`.
+- **`console.error` only, never `console.log`.** Enforced by
+  [`eslint.config.mjs:90`](../../../eslint.config.mjs#L90):
+  `'no-console': ['error', { allow: ['error'] }]`.
+- **Registrars must not import `server.ts`.**
+  [`eslint.config.mjs` block `project/registrar-boundaries`](../../../eslint.config.mjs#L160-L177)
+  — applies to `src/prompts.ts`, `src/resources.ts`, `src/tools/**/*.ts`. No
+  step here adds such an import; do not introduce one.
+- **`exactOptionalPropertyTypes` and `noUncheckedIndexedAccess` are on**
+  ([`tsconfig.json`](../../../tsconfig.json)). Optional fields are spread
+  conditionally (`...(x ? { x } : {})`), never assigned `undefined`.
+- **Comments explain *why*, not *what*.** Match the density of the file you are
+  editing; do not add narration to a line that reads plainly.
+
+## Commands
+
+| Purpose      | Command                | Expected on success                     |
+| ------------ | ---------------------- | --------------------------------------- |
+| Drift check  | `git diff --stat 8bf08572..HEAD -- src/ __tests__/ README.md` | no output at start of run |
+| Static check | `npm run check:static`  | exit 0 — build, both typechecks, eslint, prettier, knip all clean |
+| Tests        | `npm test`              | exit 0, `pass 277` at start, `fail 0` always |
+| Format + fix | `npm run fix`           | exit 0; runs prettier and eslint --fix, then the full check |
+
+`npm run check:static` takes roughly 40s; `npm test` roughly 15s.
+
+## Scope
+
+**In scope** — the only files to modify:
+
+- [`src/server.ts`](../../../src/server.ts) — step 1
+- [`src/core/primitives.ts`](../../../src/core/primitives.ts) — step 2
+- [`src/core/util.ts`](../../../src/core/util.ts) — step 2
+- [`src/core/observability.ts`](../../../src/core/observability.ts) — step 2
+- [`src/core/glob.ts`](../../../src/core/glob.ts) — step 3
+- [`src/core/search.ts`](../../../src/core/search.ts) — step 3
+- [`src/tools/list.ts`](../../../src/tools/list.ts) — steps 3 and 4
+- [`src/tools/search-content.ts`](../../../src/tools/search-content.ts) — steps 3 and 5
+- [`src/tools/search-files.ts`](../../../src/tools/search-files.ts) — steps 3 and 5
+- [`src/tools/replace-in-files.ts`](../../../src/tools/replace-in-files.ts) — steps 3 and 5
+- [`src/tools/roots.ts`](../../../src/tools/roots.ts) — step 5
+- [`src/tools/delete-file.ts`](../../../src/tools/delete-file.ts) — step 5
+- [`src/tools/read.ts`](../../../src/tools/read.ts) — step 5
+- [`src/tools/stat.ts`](../../../src/tools/stat.ts) — step 5
+- [`src/tools/index.ts`](../../../src/tools/index.ts) — step 5
+- [`src/instructions.ts`](../../../src/instructions.ts) — steps 4 and 5
+- [`__tests__/core-fs.test.ts`](../../../__tests__/core-fs.test.ts) — steps 2 and 3
+- [`__tests__/tools.test.ts`](../../../__tests__/tools.test.ts) — steps 3 and 4
+- [`README.md`](../../../README.md) — step 6
+
+**Files out of scope** — leave alone even though they look related:
+
+- [`src/core/fmt.ts`](../../../src/core/fmt.ts) — `pageTrailer` is the owner
+  step 4 routes `list` *to*. Editing it would change the two tools that already
+  call it correctly.
+- [`src/core/cursor.ts`](../../../src/core/cursor.ts) — already supplies
+  `offset`; step 4 consumes what exists.
+- [`src/core/schema.ts`](../../../src/core/schema.ts) — `includeIgnoredField()`
+  is the flag's owner and is correct. Step 3 fixes its *translation*, not the
+  field.
+- [`src/transport/stdio.ts`](../../../src/transport/stdio.ts),
+  [`src/transport/http.ts`](../../../src/transport/http.ts) — they consume
+  `FilesystemServerContext` as a type only. `import type` binds identically to
+  an interface, so step 1 must not need to touch them. If it does, that is a
+  STOP.
+- [`src/tools/create.ts`](../../../src/tools/create.ts),
+  [`edit.ts`](../../../src/tools/edit.ts),
+  [`move.ts`](../../../src/tools/move.ts),
+  [`patch.ts`](../../../src/tools/patch.ts),
+  [`diff.ts`](../../../src/tools/diff.ts) — their filenames already match their
+  wire names and they do not walk files. Nothing here touches them.
+- [`package.json`](../../../package.json),
+  [`server.json`](../../../server.json) — versions are bumped only by the
+  Release workflow. Never hand-edit either.
+- `docs/plan/**` — effort records.
+
+## Steps
+
+### 1. Replace `FilesystemServerContext` with an interface
+
+In [`src/server.ts`](../../../src/server.ts) only.
+
+Delete the class at [`server.ts:31-60`](../../../src/server.ts#L31-L60) and put
+in its place the interface it already is to every consumer:
+
+```ts
+export interface FilesystemServerContext {
+  readonly mcp: McpServer;
+  readonly pathGuard: PathGuard;
+  disposeRuntimeState(): void;
+}
+```
+
+`pages` leaves the surface — it has no reader.
+
+Replace the `new FilesystemServerContext(...)` return at
+[`server.ts:195-201`](../../../src/server.ts#L195-L201) with an object literal
+whose `disposeRuntimeState` closes over the locals already in scope:
+
+```ts
+  // False when the store is shared across instances and outlives this one.
+  const ownsPages = extraDeps?.pageStore === undefined;
+  let cleanedUp = false;
+  return {
+    mcp: server,
+    pathGuard,
+    disposeRuntimeState() {
+      if (cleanedUp) return;
+      cleanedUp = true;
+      if (ownsPages) pageStore.clear();
+      resourceDisposable.dispose();
+    },
+  };
+```
+
+> Write `resourceDisposable.dispose()`, **not** `resourceDisposable?.dispose()`.
+> `registerResources` is declared non-nullable at
+> [`resources.ts:425`](../../../src/resources.ts#L425), so the optional chain
+> becomes an unnecessary condition and
+> `@typescript-eslint/no-unnecessary-condition` rejects it. The optional 5th
+> constructor parameter dies with the class.
+
+**Verify**: `npm run check:static && npm test` → exit 0, `pass 277`, `fail 0`.
+
+### 2. Give the invalid-setting warning one owner
+
+Add to [`src/core/primitives.ts`](../../../src/core/primitives.ts), replacing
+the private `warnedFlagValues` block, an exported generalization. Carry the
+existing `console.error, not Logger` comment
+([`primitives.ts:41-42`](../../../src/core/primitives.ts#L41-L42)) onto it:
+
+```ts
+const warnedSettings = new Set<string>();
+
+/**
+ * Warn once per (setting, value) that a configured value was rejected, and say
+ * what was used instead. console.error, not Logger: this module stays
+ * dependency-free to avoid import cycles, and a startup misconfiguration is
+ * worth printing even when the operator asked for errors only.
+ */
+export function warnInvalidSetting(
+  name: string,
+  value: string,
+  expected: string,
+  fallback: string | number | boolean,
+): void {
+  const key = `${name}:${value}`;
+  if (warnedSettings.has(key)) return;
+  warnedSettings.add(key);
+  console.error(
+    `[warning] Invalid ${name} value: ${value} (must be ${expected}). Using default: ${String(fallback)}`,
+  );
+}
+```
+
+Point the three copies at it, each keeping its emitted text byte-identical:
+
+- [`primitives.ts:37-46`](../../../src/core/primitives.ts#L37-L46) inside
+  `parseTrueEnvFlag` → `warnInvalidSetting(name, value, '"true" or "1"', false);`
+- [`util.ts:57`](../../../src/core/util.ts#L57) →
+  `warnInvalidSetting(name, value, `${String(min)}-${String(max)}`, defaultValue);`
+  then delete `loggedWarns` ([`util.ts:9`](../../../src/core/util.ts#L9)),
+  delete `logInvalidEnvValue`
+  ([`util.ts:11-25`](../../../src/core/util.ts#L11-L25)), and delete the now-dead
+  `import { Logger } from './observability.js';`
+  ([`util.ts:4`](../../../src/core/util.ts#L4)) — its only use was line 22.
+- [`observability.ts:27-30`](../../../src/core/observability.ts#L27-L30) →
+  `warnInvalidSetting('FS_LOG_LEVEL', raw, LEVEL_ORDER.join('|'), 'info');`
+
+**Keep** `cachedRaw` / `cachedLevel`
+([`observability.ts:36-37,47-50`](../../../src/core/observability.ts#L36-L50)).
+That is the log-level memo `getLogLevel()` depends on, not a warn-dedupe store —
+its own JSDoc says so. It survives this step untouched.
+
+> This step is a **deliberate behavior change**, not a pure refactor:
+> `FS_MAX_FILE_SIZE`, `FS_MAX_READ_MANY_BYTES`, `FS_SEARCH_TIMEOUT_MS`,
+> `FS_MAX_WATCHERS`, `FS_MAX_REQUEST_BYTES`, `FS_RATE_LIMIT_RPM` and
+> `FS_KEEPALIVE_TIMEOUT_MS` typo warnings stop being suppressible by
+> `--log-level=error`, matching what `FS_ALLOW_SENSITIVE` and `FS_LOG_LEVEL`
+> already do.
+
+Nothing asserts on these strings today, so leave the check behind. Add to
+[`__tests__/core-fs.test.ts`](../../../__tests__/core-fs.test.ts) one test that
+sets `process.env['FS_LOG_LEVEL'] = 'error'` and a bad
+`process.env['FS_MAX_READ_MANY_BYTES']`, stubs `console.error` to collect calls,
+calls `getDefaultReadManyMaxTotalSize()` twice, and asserts:
+
+- the returned value is the documented default,
+- exactly **one** `[warning] Invalid FS_MAX_READ_MANY_BYTES` line was collected
+  across the two calls (once per setting, not per call),
+- the line reached stderr despite `FS_LOG_LEVEL=error`.
+
+Restore both env vars and `console.error` in the test's own cleanup.
+[`config.ts:36`](../../../src/core/config.ts#L36) guarantees `cli.logLevel` is
+unset under `node --test`, so the env var is what `getLogLevel()` reads.
+
+**Verify**: `npm run check:static && npm test` → exit 0, `pass 278`, `fail 0`.
+
+### 3. Delete `excludePatterns`; rename `respectGitignore` to `skipIgnored`
+
+One flag now selects both `DEFAULT_EXCLUDE_PATTERNS` and the `.gitignore` walk.
+`excludePatterns` never carries a custom value at any of its five call sites, so
+it is deleted rather than kept. The rename is not cosmetic: a flag named
+`respectGitignore` that also drops `node_modules` is the quiet lie that breeds
+the next ownership defect.
+
+Default polarity is unchanged throughout — flag absent still means "walk
+everything" — so every existing test keeps its current semantics.
+
+In [`src/core/glob.ts`](../../../src/core/glob.ts):
+
+1. [`:196`](../../../src/core/glob.ts#L196) delete `excludePatterns?: readonly string[];`
+2. [`:202`](../../../src/core/glob.ts#L202) rename `respectGitignore?: boolean;` → `skipIgnored?: boolean;`
+3. [`:306`](../../../src/core/glob.ts#L306) derive the excludes from the flag:
+   `exclude: options.skipIgnored ? DEFAULT_EXCLUDE_PATTERNS.map(toPosixPath) : [],`
+4. [`:411`](../../../src/core/glob.ts#L411) `if (options.respectGitignore)` → `if (options.skipIgnored)`
+
+In [`src/core/search.ts`](../../../src/core/search.ts):
+
+5. [`:174-175`](../../../src/core/search.ts#L174-L175) delete `excludePatterns?: string[];`, rename `respectGitignore` → `skipIgnored`
+6. [`:224-226`](../../../src/core/search.ts#L224-L226) drop the `excludePatterns` line; `skipIgnored: Boolean(options.skipIgnored),`
+7. [`:343`](../../../src/core/search.ts#L343) delete the `excludePatterns: string[],` **positional parameter** of `searchFiles`
+8. [`:348`](../../../src/core/search.ts#L348) rename the option; [`:369-371`](../../../src/core/search.ts#L369-L371) drop `excludePatterns`, pass `skipIgnored`
+
+In the four tools — each collapses to one line, `skipIgnored: !args.includeIgnored`:
+
+9. [`search-content.ts:193,198`](../../../src/tools/search-content.ts#L193-L198)
+10. [`replace-in-files.ts:503,505`](../../../src/tools/replace-in-files.ts#L503-L505)
+11. [`search-files.ts:147,152`](../../../src/tools/search-files.ts#L147-L152) —
+    also drop the `excludePatterns` argument from the `searchFiles(...)` call at
+    [`:156-162`](../../../src/tools/search-files.ts#L156-L162), and note that
+    `Parameters<typeof searchFiles>[3]` at
+    [`:148`](../../../src/tools/search-files.ts#L148) becomes
+    `Parameters<typeof searchFiles>[2]`
+12. [`list.ts:79-81`](../../../src/tools/list.ts#L79-L81) delete
+    `gitignoreMatcher`; [`:92`](../../../src/tools/list.ts#L92) replace
+    `excludePatterns` with `skipIgnored: !options.includeIgnored`;
+    [`:110-112`](../../../src/tools/list.ts#L110-L112) delete the
+    `isIgnored` / `continue` block; [`:10`](../../../src/tools/list.ts#L10)
+    reduce the import to `import { globEntries } from '../core/glob.js';`
+
+Then drop the four `[]` positionals in
+[`core-fs.test.ts:203,207,217,223`](../../../__tests__/core-fs.test.ts#L203-L223).
+
+> If `knip` now reports `DEFAULT_EXCLUDE_PATTERNS`
+> ([`glob.ts:425`](../../../src/core/glob.ts#L425)) or `loadRootGitignore`
+> ([`glob.ts:172`](../../../src/core/glob.ts#L172)) as unused exports — both lose
+> their last caller outside `glob.ts` in this step — drop the `export` keyword
+> from each. Do not delete them; `glob.ts` still uses both internally.
+
+`list` is the one tool whose observable behavior moves here, so pin it. Add to
+[`__tests__/tools.test.ts`](../../../__tests__/tools.test.ts), beside the other
+`list` cases, a test that creates a directory holding `.gitignore` with
+`ignored/`, a file `ignored/deep/buried.txt`, and a file `kept.txt`, then calls
+`list` with default flags and asserts:
+
+- `kept.txt` appears,
+- neither `ignored` nor `buried.txt` appears — the children of an ignored
+  directory stay out, not just the directory itself,
+- calling again with `includeIgnored: true` returns all three.
+
+**Verify**: `npm run check:static && npm test` → exit 0, `pass 279`, `fail 0`.
+
+### 4. Route `list` through `pageTrailer`
+
+In [`src/tools/list.ts`](../../../src/tools/list.ts):
+
+1. Add a new import line — `list.ts` has no `../core/fmt.js` import today:
+   `import { pageTrailer } from '../core/fmt.js';`
+2. [`:264-268`](../../../src/tools/list.ts#L264-L268) add `offset: number;` to
+   `handleList`'s return type.
+3. [`:325-329`](../../../src/tools/list.ts#L325-L329) add `offset: paged.offset,`
+   to its return object.
+4. [`:358-375`](../../../src/tools/list.ts#L358-L375) replace the hand-rolled
+   trailer with:
+
+```ts
+    const { structured, markdown, offset, link } = await handleList(args, ctx);
+    const text =
+      markdown +
+      pageTrailer({
+        offset,
+        shown: structured.entryCount,
+        total: structured.totalEntries,
+        noun: 'entries',
+        tool: 'list',
+        nextCursor: structured.nextCursor,
+      }) +
+      (structured.resourceUri !== undefined ? `\nfull tree at ${structured.resourceUri}` : '');
+    return {
+      structured,
+      text,
+      ...(link ? { resources: [link] } : {}),
+    };
+```
+
+Do not pass `stoppedReason` — `list` has none. The first-page
+`full tree at <uri>` line stays as its truncation signal; the counts that used
+to precede it are now in the position line, so they are dropped from it.
+
+5. Fix the claim this makes false at
+   [`instructions.ts:71`](../../../src/instructions.ts#L71). All three paged
+   tools now carry the cursor in the trailer text *and* in `_meta`, so the
+   `the text (list) or _meta (find_files, search_text)` split is no longer true.
+   Replace that whole array element with exactly this string — do not paraphrase
+   it, the assertion in item 5b matches on it:
+
+```ts
+      'pagination: nextCursor appears in the result text and in _meta, backed by a snapshot on the same ~60s clock. Page through promptly; if a cursor is rejected, start again without one. resourceUri appears on the first page only.',
+```
+
+   Only the first sentence changes; the rest of the element is byte-identical to
+   what is there today.
+
+5b. Gate that edit. Nothing in the suite reads this line — the tests that touch
+   `buildSectionsRecord` compare its output to itself, and TC-FUNC-055's
+   constraints walk stops one key short of it. Extend that walk: in
+   [`__tests__/resources.test.ts`](../../../__tests__/resources.test.ts), after
+   [`:64`](../../../__tests__/resources.test.ts#L64)
+   (`assert.match(constraints, /ephemeral_results:/);`) add
+
+```ts
+      assert.match(constraints, /pagination: nextCursor appears in the result text and in _meta,/);
+```
+
+   This is the only check in the plan that fails on an unedited, wrongly-edited,
+   or paraphrased line 71. It is a new assertion inside an existing test, so the
+   test count does not change.
+
+6. TC-FUNC-075
+   ([`tools.test.ts:734-756`](../../../__tests__/tools.test.ts#L734-L756))
+   **breaks** — it extracts the cursor with `/^nextCursor: (\S+)$/m` and asserts
+   that pattern's absence on the last page. Rewrite it against the new format,
+   mirroring the `search_text` case at
+   [`tools.test.ts:1457-1458`](../../../__tests__/tools.test.ts#L1457-L1458):
+
+   - extract with `/^\/\/ showing 1-2 of 4 entries\. Next page: list \{"cursor":"([^"]+)"\}$/m`
+   - keep the existing assertion that the extracted cursor equals
+     `_meta.nextCursor`
+   - replace the absence assertion at
+     [`:755`](../../../__tests__/tools.test.ts#L755) with the positive pair:
+     `assert.match(secondText, /^\/\/ showing 3-4 of 4 entries\.$/m)` and
+     `assert.doesNotMatch(secondText, /Next page/)`
+
+**Verify**: `npm run check:static && npm test` → exit 0, `pass 279`, `fail 0`.
+
+### 5. Rename each tool's file and constant to its wire name
+
+Five file renames — use `git mv` so history follows:
+
+```
+git mv src/tools/search-content.ts src/tools/search-text.ts
+git mv src/tools/search-files.ts src/tools/find-files.ts
+git mv src/tools/replace-in-files.ts src/tools/replace-text.ts
+git mv src/tools/roots.ts src/tools/list-roots.ts
+git mv src/tools/delete-file.ts src/tools/delete.ts
+```
+
+Seven constant renames, in the file that declares each and at every use:
+
+| Constant today             | Becomes      | Declared in                 |
+| :------------------------- | :----------- | :-------------------------- |
+| `SEARCH_CONTENT`           | `SEARCH_TEXT`| `src/tools/search-text.ts`  |
+| `SEARCH_FILES`             | `FIND_FILES` | `src/tools/find-files.ts`   |
+| `SEARCH_AND_REPLACE`       | `REPLACE_TEXT` | `src/tools/replace-text.ts` |
+| `LIST_ALLOWED_DIRECTORIES` | `LIST_ROOTS` | `src/tools/list-roots.ts`   |
+| `DELETE_FILE`              | `DELETE`     | `src/tools/delete.ts`       |
+| `GET_FILE_INFO`            | `STAT`       | `src/tools/stat.ts`         |
+| `READ_FILE`                | `READ`       | `src/tools/read.ts`         |
+
+`stat.ts` and `read.ts` keep their filenames — those already match the wire name.
+
+The only two modules to update are
+[`src/tools/index.ts`](../../../src/tools/index.ts) (its imports at
+[`:6-19`](../../../src/tools/index.ts#L6-L19), the `ALL_TOOLS` array at
+[`:21-35`](../../../src/tools/index.ts#L21-L35), and the re-export at
+[`:51`](../../../src/tools/index.ts#L51)) and
+[`src/instructions.ts`](../../../src/instructions.ts) (its import at
+[`:6-14`](../../../src/instructions.ts#L6-L14) and the constant uses through
+`buildToolsOverview` and `buildSectionsRecord`).
+
+**Change no `name:` string.** The wire names are the contract and are already
+correct; this step moves the filenames and constants onto them, never the
+reverse. `git diff` must show zero changes to any line matching `name: '`.
+
+Sort order matters to lint: `@trivago/prettier-plugin-sort-imports` orders the
+import block, so run `npm run fix` rather than hand-sorting.
+
+**Verify**: `npm run fix` → exit 0. Then
+`git diff --stat 8bf08572..HEAD -- src/tools/ | grep -c 'name:'` → `0`, and
+`npm test` → `pass 279`, `fail 0`.
+
+### 6. Correct the README structure table
+
+In [`README.md`](../../../README.md) only.
+
+1. Delete the `scripts/` line from the tree block at
+   [`README.md:259-272`](../../../README.md#L259-L272) — the directory does not
+   exist.
+2. In the path table at
+   [`README.md:278-285`](../../../README.md#L278-L285), change the
+   `src/tools/batch.ts` row's description from
+   `Batch helpers (runOverPaths, normalizeBatchItems)` to name only the actual
+   exports: `runOverPaths` and `isTotalFailure`.
+
+Leave the rest of the section alone — the declared gradient at
+[`README.md:274-276`](../../../README.md#L274-L276) is correct.
+
+**Verify**: `npm run check:static` → exit 0 (prettier checks Markdown), and
+`grep -c 'scripts/' README.md` → `0`.
+
+## Done
+
+All must hold:
+
+- [ ] `npm run check:static` exits 0
+- [ ] `npm test` exits 0 with `fail 0` and `pass 279` — 277 baseline plus the
+      invalid-setting warning test (step 2) and the gitignored-children test
+      (step 3)
+- [ ] `grep -rn 'excludePatterns\|respectGitignore' src` returns nothing
+- [ ] `grep -rn 'FilesystemServerContext' src` shows only the interface
+      declaration in `server.ts` and `import type` lines
+- [ ] `grep -rn 'SEARCH_CONTENT\|SEARCH_FILES\|SEARCH_AND_REPLACE\|LIST_ALLOWED_DIRECTORIES\|DELETE_FILE\|GET_FILE_INFO\|READ_FILE' src`
+      returns nothing
+- [ ] `git diff 8bf08572..HEAD -- src/tools/ | grep "name: '"` returns nothing —
+      no wire name changed
+- [ ] `grep -c 'the text (list) or _meta' src/instructions.ts` returns `0`, and
+      `grep -c 'nextCursor appears in the result text and in _meta' src/instructions.ts`
+      returns `1` — the pagination claim was corrected, not merely touched
+- [ ] `git status` shows no files outside the in-scope list
+
+## STOP
+
+Stop and report if:
+
+- The code at a [Current state](#current-state) location does not match its
+  excerpt.
+- A step's verification fails twice after one fix attempt — a second failure
+  means the step's assumption is wrong, not its implementation.
+- The fix appears to require an out-of-scope file.
+- **Step 1**: removing the class forces an edit to
+  [`src/transport/stdio.ts`](../../../src/transport/stdio.ts) or
+  [`src/transport/http.ts`](../../../src/transport/http.ts). They bind the name
+  with `import type`, which resolves to an interface identically; a required
+  edit there means something reads `.pages` or constructs the class, and the
+  grep behind this plan missed it.
+- **Step 2**: any existing test starts failing on a log line. That would mean a
+  suite depends on `util.ts`'s warning being suppressed at `error` level — the
+  exact behavior this step changes — and the change needs the user's call, not
+  a workaround.
+- **Step 3**: the new `list` test shows a gitignored directory's children still
+  present, or a previously-listed entry disappearing. Walk-time pruning is
+  assumed equivalent to post-filtering because git forbids re-including a path
+  under an ignored directory. If the sets differ, that assumption is false and
+  the step is wrong, not the test.
+- **Step 5**: any `name:` string differs from `8bf08572`. A changed wire name is
+  a breaking protocol change and the opposite of this step's intent.
+
+## Notes
+
+- **Review focus.** Step 3 is the one with real behavioral risk and the widest
+  blast radius; step 2 changes observable output deliberately. Steps 1, 4, 5 and
+  6 are mechanical once their gates pass.
+- **Step 1 is independently verified.** The move was executed during the audit:
+  `check:static` clean, 277/277 pass. If it fails here, drift is the first
+  suspect — run the drift check.
+- **Order is load-bearing between steps 3 and 4.** Step 3 changes which entries
+  `list` returns, and therefore the totals step 4's new trailer prints. Doing 4
+  first means writing assertions against counts that step 3 then invalidates.
+- **Step 5 goes last on purpose.** It renames files that steps 3 and 4 edit;
+  running it earlier rewrites every later diff's paths for no gain.
+- **Deliberately deferred.** Fourteen further audit candidates were dropped at
+  the audit's bar — mostly moves whose product was a new shared module, plus
+  everything in `src/transport/` (30 commits in twelve months earns no
+  restructure). They are not in this plan and should not be smuggled in.
+- **Rollback.** No migrations, no data, no deletions beyond source. `git revert`
+  the step's commit, or `git checkout 8bf08572 -- <path>` for a single file.
+  Commit per step so this stays true.

--- a/src/core/glob.ts
+++ b/src/core/glob.ts
@@ -63,7 +63,7 @@ async function loadGitignoreFiles(
   );
 }
 
-export class GitignoreManager {
+class GitignoreManager {
   private matchers = new Map<string, Ignore>();
 
   addMatcher(dir: string, matcher: Ignore): void {
@@ -169,7 +169,7 @@ export class GitignoreManager {
   }
 }
 
-export async function loadRootGitignore(
+async function loadRootGitignore(
   root: string,
   signal?: AbortSignal,
 ): Promise<GitignoreManager | null> {
@@ -193,13 +193,15 @@ export interface GlobEntry {
 export interface GlobEntriesOptions {
   cwd: string;
   pattern: string;
-  excludePatterns?: readonly string[];
   includeHidden?: boolean;
   baseNameMatch?: boolean;
   maxDepth?: number;
   onlyFiles?: boolean;
   suppressErrors?: boolean;
-  respectGitignore?: boolean;
+  /** Skip what a walk should not surface: DEFAULT_EXCLUDE_PATTERNS and .gitignore. */
+  skipIgnored?: boolean;
+  /** Bounds the `.gitignore` discovery `skipIgnored` runs before the walk. */
+  signal?: AbortSignal;
 }
 
 interface NormalizedGlob {
@@ -303,7 +305,7 @@ function normalizeGlobOptions(options: GlobEntriesOptions): NormalizedGlob {
   const normalized: NormalizedGlob = {
     cwd,
     patterns,
-    exclude: (options.excludePatterns ?? []).map(toPosixPath),
+    exclude: options.skipIgnored ? DEFAULT_EXCLUDE_PATTERNS.map(toPosixPath) : [],
     suppressErrors: options.suppressErrors ?? false,
   };
 
@@ -396,6 +398,10 @@ async function* processGlobPattern(
 
   try {
     for await (const match of iterable) {
+      // A function `exclude` only prunes descent in fs.glob — it still yields
+      // the rejected dirent itself, and any rejected entry below the top level.
+      // An array `exclude` drops both. Re-apply the predicate so the two agree.
+      if (typeof excludeFunc === 'function' && excludeFunc(match)) continue;
       yield* processDirentMatch(match, cwd, maxDepth, seen, onlyFiles);
     }
   } catch (error) {
@@ -408,8 +414,8 @@ async function* processGlobPattern(
 
 export async function* globEntries(options: GlobEntriesOptions): AsyncGenerator<GlobEntry> {
   let gitignoreMatcher: GitignoreManager | null = null;
-  if (options.respectGitignore) {
-    gitignoreMatcher = await loadRootGitignore(options.cwd);
+  if (options.skipIgnored) {
+    gitignoreMatcher = await loadRootGitignore(options.cwd, options.signal);
   }
 
   const plan = normalizeGlobOptions(options);
@@ -422,7 +428,7 @@ export async function* globEntries(options: GlobEntriesOptions): AsyncGenerator<
   }
 }
 
-export const DEFAULT_EXCLUDE_PATTERNS = [
+const DEFAULT_EXCLUDE_PATTERNS = [
   '**/node_modules',
   '**/node_modules/**',
   '**/dist',

--- a/src/core/observability.ts
+++ b/src/core/observability.ts
@@ -1,4 +1,5 @@
 import { cli } from './config.js';
+import { warnInvalidSetting } from './primitives.js';
 
 export type LoggingLevel =
   'debug' | 'info' | 'notice' | 'warning' | 'error' | 'critical' | 'alert' | 'emergency';
@@ -25,9 +26,7 @@ function parseLogLevel(raw: string | undefined): LoggingLevel {
   // `warn` is the common short form; the canonical RFC 5424 level is `warning`.
   if (raw === 'warn') return 'warning';
   if (isLoggingLevel(raw)) return raw;
-  console.error(
-    `[warning] Invalid FS_LOG_LEVEL value: ${raw} (must be ${LEVEL_ORDER.join('|')}). Using default: info`,
-  );
+  warnInvalidSetting('FS_LOG_LEVEL', raw, LEVEL_ORDER.join('|'), 'info');
   return 'info';
 }
 

--- a/src/core/primitives.ts
+++ b/src/core/primitives.ts
@@ -23,7 +23,27 @@ export function resolveEntryType(dirent: DirentLike): EntryType {
   return 'other';
 }
 
-const warnedFlagValues = new Set<string>();
+const warnedSettings = new Set<string>();
+
+/**
+ * Warn once per (setting, value) that a configured value was rejected, and say
+ * what was used instead. console.error, not Logger: this module stays
+ * dependency-free to avoid import cycles, and a startup misconfiguration is
+ * worth printing even when the operator asked for errors only.
+ */
+export function warnInvalidSetting(
+  name: string,
+  value: string,
+  expected: string,
+  fallback: string | number | boolean,
+): void {
+  const key = `${name}:${value}`;
+  if (warnedSettings.has(key)) return;
+  warnedSettings.add(key);
+  console.error(
+    `[warning] Invalid ${name} value: ${value} (must be ${expected}). Using default: ${String(fallback)}`,
+  );
+}
 
 /**
  * Parse a boolean env flag: `true`/`1` enable, `false`/`0`/empty disable.
@@ -35,15 +55,7 @@ export function parseTrueEnvFlag(value: string | undefined, name?: string): bool
   const trimmed = value.trim().toLowerCase();
   if (trimmed === 'true' || trimmed === '1') return true;
   if (name && trimmed !== '' && trimmed !== 'false' && trimmed !== '0') {
-    const key = `${name}:${trimmed}`;
-    if (!warnedFlagValues.has(key)) {
-      warnedFlagValues.add(key);
-      // console.error, not Logger: this module stays dependency-free to avoid
-      // import cycles (same precedent as parseLogLevel in observability.ts).
-      console.error(
-        `[warning] Invalid ${name} value: ${value} (must be "true" or "1"). Using default: false`,
-      );
-    }
+    warnInvalidSetting(name, value, '"true" or "1"', false);
   }
   return false;
 }

--- a/src/core/search.ts
+++ b/src/core/search.ts
@@ -171,8 +171,7 @@ export interface SearchContentOptions {
   isRegex?: boolean;
   maxResults?: number;
   filePattern?: string;
-  excludePatterns?: string[];
-  respectGitignore?: boolean;
+  skipIgnored?: boolean;
   includeHidden?: boolean;
   maxDepth?: number;
   signal?: AbortSignal;
@@ -221,9 +220,9 @@ export async function searchContent(
     const entries = globEntries({
       cwd: directory,
       pattern: options.filePattern ?? '**/*',
-      excludePatterns: options.excludePatterns ?? [],
       includeHidden: Boolean(options.includeHidden),
-      respectGitignore: Boolean(options.respectGitignore),
+      skipIgnored: Boolean(options.skipIgnored),
+      ...(options.signal ? { signal: options.signal } : {}),
       maxDepth: options.maxDepth ?? 100,
       suppressErrors: true,
     });
@@ -340,12 +339,11 @@ async function* guardedEntries(
 export async function searchFiles(
   directory: string,
   pattern: string,
-  excludePatterns: string[],
   options: {
     maxResults?: number;
     includeHidden?: boolean;
     sortBy?: 'name' | 'path';
-    respectGitignore?: boolean;
+    skipIgnored?: boolean;
     maxDepth?: number;
     signal?: AbortSignal;
   },
@@ -366,9 +364,9 @@ export async function searchFiles(
   const entries = globEntries({
     cwd: directory,
     pattern,
-    excludePatterns,
     includeHidden: Boolean(options.includeHidden),
-    respectGitignore: Boolean(options.respectGitignore),
+    skipIgnored: Boolean(options.skipIgnored),
+    ...(options.signal ? { signal: options.signal } : {}),
     maxDepth: options.maxDepth ?? 100,
     suppressErrors: true,
   });

--- a/src/core/util.ts
+++ b/src/core/util.ts
@@ -1,28 +1,10 @@
 import { availableParallelism } from 'node:os';
 
 import { cli } from './config.js';
-import { Logger } from './observability.js';
+import { warnInvalidSetting } from './primitives.js';
 
 const KIB = 1024;
 export const MIB = 1024 * KIB;
-
-const loggedWarns = new Set<string>();
-
-function logInvalidEnvValue(
-  envVar: string,
-  value: string,
-  expected: string,
-  defaultValue: number | boolean,
-): void {
-  const key = `${envVar}:${value}:${expected}`;
-  if (loggedWarns.has(key)) {
-    return;
-  }
-  loggedWarns.add(key);
-  Logger.warn(
-    `Invalid ${envVar} value: ${value} (must be ${expected}). Using default: ${String(defaultValue)}`,
-  );
-}
 
 export function parseEnvInt(
   envVar: string,
@@ -54,7 +36,7 @@ function parseIntSetting(
     parsed < min ||
     parsed > max
   ) {
-    logInvalidEnvValue(name, value, `${String(min)}-${String(max)}`, defaultValue);
+    warnInvalidSetting(name, value, `${String(min)}-${String(max)}`, defaultValue);
     return defaultValue;
   }
   return parsed;

--- a/src/instructions.ts
+++ b/src/instructions.ts
@@ -4,20 +4,20 @@ import {
   MAX_SEARCH_RESULTS,
 } from './core/util.js';
 import {
-  GET_FILE_INFO,
+  FIND_FILES,
   LIST,
-  LIST_ALLOWED_DIRECTORIES,
+  LIST_ROOTS,
   MUTATING_TOOL_NAMES,
-  READ_FILE,
-  SEARCH_CONTENT,
-  SEARCH_FILES,
+  READ,
+  SEARCH_TEXT,
+  STAT,
 } from './tools/index.js';
 
 function buildToolsOverview(readOnly: boolean): string {
   const rows: [string, string[]][] = [
-    ['Navigate', [LIST_ALLOWED_DIRECTORIES.name, LIST.name, SEARCH_FILES.name]],
-    ['Inspect', [GET_FILE_INFO.name, SEARCH_CONTENT.name]],
-    ['Read', [READ_FILE.name]],
+    ['Navigate', [LIST_ROOTS.name, LIST.name, FIND_FILES.name]],
+    ['Inspect', [STAT.name, SEARCH_TEXT.name]],
+    ['Read', [READ.name]],
   ];
 
   // Under --read-only the mutating tools are never registered, so advertising
@@ -49,9 +49,9 @@ export function buildSectionsRecord(readOnly: boolean): Record<string, string> {
     guidelines: [
       'Guidelines:',
       '```',
-      `root_access: ${LIST_ALLOWED_DIRECTORIES.name} lists configured or accepted roots; every other tool is scoped to them.`,
+      `root_access: ${LIST_ROOTS.name} lists configured or accepted roots; every other tool is scoped to them.`,
       'modern_root_grants: Modern clients do not automatically send workspace roots. Call a tool with a concrete path and approve its grant when elicitation is available.',
-      `path_resolution: Confirm a path with ${LIST.name} or ${SEARCH_FILES.name} before acting on it.`,
+      `path_resolution: Confirm a path with ${LIST.name} or ${FIND_FILES.name} before acting on it.`,
       '```',
     ].join('\n'),
     tools_overview: [
@@ -63,20 +63,20 @@ export function buildSectionsRecord(readOnly: boolean): Record<string, string> {
     constraints: [
       'Constraints:',
       '```',
-      `allowed_roots: Startup roots come from CLI paths, FS_ALLOWED_DIRS, or --allow-cwd; accepted modern grants are additive. Call ${LIST_ALLOWED_DIRECTORIES.name} to read the current set.`,
+      `allowed_roots: Startup roots come from CLI paths, FS_ALLOWED_DIRS, or --allow-cwd; accepted modern grants are additive. Call ${LIST_ROOTS.name} to read the current set.`,
       'legacy_roots: Legacy clients may additionally seed roots through the deprecated roots/list flow.',
       'sensitive_paths: Sensitive file paths (.env, *.pem, *id_rsa*) are denied by default.',
       `enforced_limits: max file size ${maxFileMb} MB, file search cap ${MAX_SEARCH_RESULTS} results, content search cap ${DEFAULT_SEARCH_CONTENT_RESULTS} matches.`,
       'ephemeral_results: When a result carries a resource_link or a resourceUri (in structuredContent or _meta), call resources/read immediately — cached results are ephemeral and expire after ~60 seconds, eviction, or restart.',
-      'pagination: nextCursor appears in the text (list) or _meta (find_files, search_text) and is backed by a snapshot on the same ~60s clock. Page through promptly; if a cursor is rejected, start again without one. resourceUri appears on the first page only.',
+      'pagination: nextCursor appears in the result text and in _meta, backed by a snapshot on the same ~60s clock. Page through promptly; if a cursor is rejected, start again without one. resourceUri appears on the first page only.',
       '```',
     ].join('\n'),
     error_recovery: [
       'Error Recovery:',
       '```',
-      `ACCESS_DENIED: Run ${LIST_ALLOWED_DIRECTORIES.name}; configure a missing startup root or retry a concrete path and approve the grant.`,
-      `NOT_FOUND: Run ${LIST.name} or ${SEARCH_FILES.name} to verify the path.`,
-      `TOO_LARGE: Use ${READ_FILE.name} with head/tail or startLine/endLine, or split across several calls.`,
+      `ACCESS_DENIED: Run ${LIST_ROOTS.name}; configure a missing startup root or retry a concrete path and approve the grant.`,
+      `NOT_FOUND: Run ${LIST.name} or ${FIND_FILES.name} to verify the path.`,
+      `TOO_LARGE: Use ${READ.name} with head/tail or startLine/endLine, or split across several calls.`,
       'TIMEOUT: Reduce scope, depth, or maxResults.',
       'INVALID_INPUT: Re-read the tool schema in tools/list.',
       '```',

--- a/src/server.ts
+++ b/src/server.ts
@@ -28,35 +28,10 @@ const {
   homepage: SERVER_HOMEPAGE,
 } = packageJson;
 
-export class FilesystemServerContext {
-  public readonly mcp: McpServer;
-  public readonly pathGuard: PathGuard;
-  public readonly pages: PageSnapshotStore;
-  /** False when the store is shared across instances and outlives this one. */
-  private readonly ownsPages: boolean;
-  private readonly resourceDisposable?: { dispose(): void } | undefined;
-  private cleanedUp = false;
-
-  constructor(
-    mcp: McpServer,
-    pathGuard: PathGuard,
-    pages: PageSnapshotStore,
-    ownsPages: boolean,
-    resourceDisposable?: { dispose(): void },
-  ) {
-    this.mcp = mcp;
-    this.pathGuard = pathGuard;
-    this.pages = pages;
-    this.ownsPages = ownsPages;
-    this.resourceDisposable = resourceDisposable;
-  }
-
-  disposeRuntimeState(): void {
-    if (this.cleanedUp) return;
-    this.cleanedUp = true;
-    if (this.ownsPages) this.pages.clear();
-    this.resourceDisposable?.dispose();
-  }
+export interface FilesystemServerContext {
+  readonly mcp: McpServer;
+  readonly pathGuard: PathGuard;
+  disposeRuntimeState(): void;
 }
 
 export async function createServer(
@@ -192,11 +167,17 @@ export async function createServer(
   registerPrompts(deps);
   registerTools(deps);
 
-  return new FilesystemServerContext(
-    server,
+  // False when the store is shared across instances and outlives this one.
+  const ownsPages = extraDeps?.pageStore === undefined;
+  let cleanedUp = false;
+  return {
+    mcp: server,
     pathGuard,
-    pageStore,
-    extraDeps?.pageStore === undefined,
-    resourceDisposable,
-  );
+    disposeRuntimeState() {
+      if (cleanedUp) return;
+      cleanedUp = true;
+      if (ownsPages) pageStore.clear();
+      resourceDisposable.dispose();
+    },
+  };
 }

--- a/src/tools/delete.ts
+++ b/src/tools/delete.ts
@@ -401,7 +401,7 @@ async function handleDelete(
   };
 }
 
-export const DELETE_FILE = defineTool({
+export const DELETE = defineTool({
   name: 'delete',
   title: 'Delete File',
   description:

--- a/src/tools/find-files.ts
+++ b/src/tools/find-files.ts
@@ -4,7 +4,6 @@ import { SearchStoppedReasonSchema } from '../core/concurrency.js';
 import { pageQueryKey, paginate } from '../core/cursor.js';
 import { ErrorCode } from '../core/errors.js';
 import { formatCount, pageTrailer, truncateProgressPattern } from '../core/fmt.js';
-import { DEFAULT_EXCLUDE_PATTERNS } from '../core/glob.js';
 import { toPosixRelative } from '../core/path.js';
 import {
   CursorSchema,
@@ -144,22 +143,15 @@ async function handleSearchFiles(
     pageSize: args.maxResults,
     produce: async () => {
       const basePath = await ctx.fs.pathGuard.validateExistingDirectory(requestedBasePath);
-      const excludePatterns = args.includeIgnored ? [] : DEFAULT_EXCLUDE_PATTERNS;
-      const searchOptions: Parameters<typeof searchFiles>[3] = {
+      const searchOptions: Parameters<typeof searchFiles>[2] = {
         maxResults: MAX_SEARCH_RESULTS,
         includeHidden: args.includeHidden,
         sortBy: args.sortBy,
-        respectGitignore: !args.includeIgnored,
+        skipIgnored: !args.includeIgnored,
         ...(args.maxDepth !== undefined ? { maxDepth: args.maxDepth } : {}),
         signal: ctx.signal,
       };
-      const result = await searchFiles(
-        basePath,
-        args.pattern,
-        excludePatterns,
-        searchOptions,
-        ctx.fs.pathGuard,
-      );
+      const result = await searchFiles(basePath, args.pattern, searchOptions, ctx.fs.pathGuard);
       return {
         items: buildRelativeResults(result.basePath, result.results),
         metadata: {
@@ -194,7 +186,7 @@ async function handleSearchFiles(
   };
 }
 
-export const SEARCH_FILES = defineTool({
+export const FIND_FILES = defineTool({
   name: 'find_files',
   title: 'Find Files',
   description:

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -5,33 +5,33 @@ import type { PathGuard } from '../core/path.js';
 import type { ResourceStore } from '../core/store.js';
 import { CREATE } from './create.js';
 import type { DefinedTool } from './define.js';
-import { DELETE_FILE } from './delete-file.js';
+import { DELETE } from './delete.js';
 import { DIFF } from './diff.js';
 import { EDIT } from './edit.js';
+import { FIND_FILES } from './find-files.js';
+import { LIST_ROOTS } from './list-roots.js';
 import { LIST } from './list.js';
 import { MOVE } from './move.js';
 import { PATCH } from './patch.js';
-import { READ_FILE } from './read.js';
-import { SEARCH_AND_REPLACE } from './replace-in-files.js';
-import { LIST_ALLOWED_DIRECTORIES } from './roots.js';
-import { SEARCH_CONTENT } from './search-content.js';
-import { SEARCH_FILES } from './search-files.js';
-import { GET_FILE_INFO } from './stat.js';
+import { READ } from './read.js';
+import { REPLACE_TEXT } from './replace-text.js';
+import { SEARCH_TEXT } from './search-text.js';
+import { STAT } from './stat.js';
 
 export const ALL_TOOLS = [
   CREATE,
-  DELETE_FILE,
+  DELETE,
   DIFF,
   EDIT,
   LIST,
   MOVE,
   PATCH,
-  READ_FILE,
-  SEARCH_AND_REPLACE,
-  LIST_ALLOWED_DIRECTORIES,
-  SEARCH_CONTENT,
-  SEARCH_FILES,
-  GET_FILE_INFO,
+  READ,
+  REPLACE_TEXT,
+  LIST_ROOTS,
+  SEARCH_TEXT,
+  FIND_FILES,
+  STAT,
 ] as const;
 
 export const MUTATING_TOOL_NAMES = new Set(
@@ -48,7 +48,7 @@ export function registeredTools(readOnly: boolean): readonly DefinedTool[] {
 // Only the read-only tools are named individually: the mutating six are no
 // longer listed by hand anywhere, so their names reach callers through
 // MUTATING_TOOL_NAMES and ALL_TOOLS instead.
-export { LIST, LIST_ALLOWED_DIRECTORIES, READ_FILE, SEARCH_CONTENT, SEARCH_FILES, GET_FILE_INFO };
+export { LIST, LIST_ROOTS, READ, SEARCH_TEXT, FIND_FILES, STAT };
 
 interface ToolRegistrarDeps {
   readonly server: McpServer;

--- a/src/tools/list-roots.ts
+++ b/src/tools/list-roots.ts
@@ -14,7 +14,7 @@ const RootsOutputSchema = z.strictObject({
     .describe('How to configure roots; present only when there are none to list'),
 });
 
-export const LIST_ALLOWED_DIRECTORIES = defineTool({
+export const LIST_ROOTS = defineTool({
   name: 'list_roots',
   title: 'Workspace Roots',
   description:

--- a/src/tools/list.ts
+++ b/src/tools/list.ts
@@ -6,8 +6,9 @@ import * as z from 'zod/v4';
 
 import { pageQueryKey, paginate } from '../core/cursor.js';
 import { ErrorCode } from '../core/errors.js';
+import { pageTrailer } from '../core/fmt.js';
 import type { EntryType } from '../core/glob.js';
-import { DEFAULT_EXCLUDE_PATTERNS, globEntries, loadRootGitignore } from '../core/glob.js';
+import { globEntries } from '../core/glob.js';
 import type { PathGuard } from '../core/path.js';
 import { toPosixRelative } from '../core/path.js';
 import { resolveEntryType } from '../core/primitives.js';
@@ -76,10 +77,6 @@ function compareEntries(a: CollectedEntry, b: CollectedEntry): number {
 }
 
 async function collect(rootPath: string, options: CollectOptions): Promise<CollectResult> {
-  const gitignoreMatcher = options.includeIgnored
-    ? null
-    : await loadRootGitignore(rootPath, options.signal);
-
   const entries: CollectedEntry[] = [];
   let scanned = 0;
   let totalEntries = 0;
@@ -89,7 +86,8 @@ async function collect(rootPath: string, options: CollectOptions): Promise<Colle
   for await (const entry of globEntries({
     cwd: rootPath,
     pattern: '**/*',
-    excludePatterns: options.includeIgnored ? [] : DEFAULT_EXCLUDE_PATTERNS,
+    skipIgnored: !options.includeIgnored,
+    signal: options.signal,
     includeHidden: options.includeHidden,
     baseNameMatch: false,
     // ListInputSchema.maxDepth is 1-based (1 = top-level only); the shared
@@ -103,13 +101,9 @@ async function collect(rootPath: string, options: CollectOptions): Promise<Colle
     options.onProgress?.({ current: scanned });
 
     const entryType: EntryType = resolveEntryType(entry.dirent);
-    const isDir = entryType === 'directory';
     const relPath = toPosixRelative(rootPath, entry.path);
     const name = basename(relPath);
 
-    if (gitignoreMatcher?.isIgnored(relPath, isDir)) {
-      continue;
-    }
     const accessible = await options.pathGuard.isEntryAccessible(entry.path);
     if (!accessible) continue;
 
@@ -264,6 +258,7 @@ async function handleList(
 ): Promise<{
   structured: z.infer<typeof ListOutputSchema>;
   markdown: string;
+  offset: number;
   link?: ContentBlock;
 }> {
   const path = args.path;
@@ -325,6 +320,7 @@ async function handleList(
   return {
     structured: listOutput(paged.page, paged.metadata, paged.nextCursor, paged.resource?.entry.uri),
     markdown: renderMarkdown(basename(paged.metadata.path), [...paged.page]),
+    offset: paged.offset,
     ...(paged.resource ? { link: paged.resource.link } : {}),
   };
 }
@@ -355,22 +351,24 @@ export const LIST = defineTool({
   }),
   accessPaths: (args) => (args.path ? [args.path] : []),
   run: async (args, ctx) => {
-    const { structured, markdown, link } = await handleList(args, ctx);
-    // The tree is what the model reads; nextCursor and the full-list URI used
-    // to reach it only through the structured half, which now ships as _meta.
-    // Both ride the text so paging needs no second lookup.
-    const trailer: string[] = [];
-    if (structured.nextCursor !== undefined) {
-      trailer.push(`nextCursor: ${structured.nextCursor}`);
-    }
-    if (structured.resourceUri !== undefined) {
-      trailer.push(
-        `${String(structured.entryCount)} of ${String(structured.totalEntries)} entries shown; full tree at ${structured.resourceUri}`,
-      );
-    }
+    const { structured, markdown, offset, link } = await handleList(args, ctx);
+    // The tree is what the model reads, so position and the full-list URI ride
+    // the text too — paging needs no second lookup. `pageTrailer` is the one
+    // owner of that line, and it owes it on the last page as much as the first.
+    const text =
+      markdown +
+      pageTrailer({
+        offset,
+        shown: structured.entryCount,
+        total: structured.totalEntries,
+        noun: 'entries',
+        tool: 'list',
+        nextCursor: structured.nextCursor,
+      }) +
+      (structured.resourceUri !== undefined ? `\nfull tree at ${structured.resourceUri}` : '');
     return {
       structured,
-      text: trailer.length > 0 ? `${markdown}\n\n${trailer.join('\n')}` : markdown,
+      text,
       ...(link ? { resources: [link] } : {}),
     };
   },

--- a/src/tools/read.ts
+++ b/src/tools/read.ts
@@ -384,7 +384,7 @@ async function readOnePath(
   });
 }
 
-export const READ_FILE = defineTool({
+export const READ = defineTool({
   name: 'read',
   title: 'Read File',
   description:

--- a/src/tools/replace-text.ts
+++ b/src/tools/replace-text.ts
@@ -18,7 +18,7 @@ import {
 import { buildFileResourceLink } from '../core/file-uri.js';
 import { truncateProgressPattern } from '../core/fmt.js';
 import type { GuardedFileSystem } from '../core/fs.js';
-import { DEFAULT_EXCLUDE_PATTERNS, globEntries } from '../core/glob.js';
+import { globEntries } from '../core/glob.js';
 import { toPosixRelative } from '../core/path.js';
 import { escapeRegexLiteral } from '../core/primitives.js';
 import { readFileBufferWithLimit } from '../core/read.js';
@@ -500,9 +500,9 @@ async function handleSearchAndReplace(
     : globEntries({
         cwd: root,
         pattern: effectivePattern,
-        excludePatterns: args.includeIgnored ? [] : DEFAULT_EXCLUDE_PATTERNS,
         includeHidden: args.includeHidden,
-        respectGitignore: !args.includeIgnored,
+        skipIgnored: !args.includeIgnored,
+        signal: ctx.signal,
         baseNameMatch: true,
         onlyFiles: true,
         suppressErrors: true,
@@ -599,7 +599,7 @@ async function handleSearchAndReplace(
   return { structured };
 }
 
-export const SEARCH_AND_REPLACE = defineTool({
+export const REPLACE_TEXT = defineTool({
   name: 'replace_text',
   title: 'Search and Replace',
   description:

--- a/src/tools/search-text.ts
+++ b/src/tools/search-text.ts
@@ -7,7 +7,6 @@ import { SearchStoppedReasonSchema } from '../core/concurrency.js';
 import { pageQueryKey, paginate } from '../core/cursor.js';
 import { ErrorCode, FsError } from '../core/errors.js';
 import { formatCount, pageTrailer, truncateProgressPattern } from '../core/fmt.js';
-import { DEFAULT_EXCLUDE_PATTERNS } from '../core/glob.js';
 import { Logger } from '../core/observability.js';
 import { toPosixRelative } from '../core/path.js';
 import {
@@ -190,12 +189,11 @@ function buildSortedPayloads(result: SearchResultValue): SearchMatchPayload[] {
 function buildSearchContentOptions(args: SearchInput, signal?: AbortSignal): SearchContentOptions {
   return {
     includeHidden: args.includeHidden,
-    excludePatterns: args.includeIgnored ? [] : DEFAULT_EXCLUDE_PATTERNS,
     filePattern: args.pattern ?? '**/*',
     caseSensitive: args.caseSensitive,
     isRegex: args.isRegex,
     maxResults: args.maxResults,
-    respectGitignore: !args.includeIgnored,
+    skipIgnored: !args.includeIgnored,
     ...(args.maxDepth !== undefined ? { maxDepth: args.maxDepth } : {}),
     ...(signal ? { signal } : {}),
   };
@@ -314,7 +312,7 @@ async function handleSearchContent(
   };
 }
 
-export const SEARCH_CONTENT = defineTool({
+export const SEARCH_TEXT = defineTool({
   name: 'search_text',
   title: 'Search Content',
   description:

--- a/src/tools/stat.ts
+++ b/src/tools/stat.ts
@@ -160,7 +160,7 @@ function classifyTypeCounts(results: readonly PerPathResult<FileInfo>[]): {
   return { fileCount, dirCount };
 }
 
-export const GET_FILE_INFO = defineTool({
+export const STAT = defineTool({
   name: 'stat',
   title: 'Get File Info',
   description:


### PR DESCRIPTION
An architecture audit ranked this repo's structural debt by churn. Six findings cleared its bar; this lands all six. A review of the result then turned up a correctness bug — one that predates this branch for three tools — so that fix rides along.

## The fix a reviewer should look at first

`fs.glob` treats its two `exclude` forms differently, and nothing here knew that. Given `a/{kept.txt, dist/o.js, skipme/deep/buried.txt}` and a rule covering `dist` and `skipme`:

```text
ARRAY exclude   ["a", "a/kept.txt"]                       correct
FUNC  exclude   ["a", "a/dist", "a/kept.txt", "a/skipme"] leaks both dirs
```

A function `exclude` prunes *descent* but still yields the rejected dirent, and any rejected entry below the top level. Files leak the same way: `sub/drop2.log` survives a `**/*.log` function-exclude while top-level `drop.log` does not.

`createExcludeFilter` returns the array form when no `.gitignore` is found and the function form when one is — so the mere presence of a `.gitignore` anywhere under the root silently changed which entries survived the walk. `find_files`, `search_text` and `replace_text` have returned nested gitignored files this way since before this branch. `list` was insulated only by the post-filter this branch removes, so without the fix it would have regressed too.

One line at the shared chokepoint, `src/core/glob.ts`:

```ts
if (typeof excludeFunc === 'function' && excludeFunc(match)) continue;
```

Verified by removing it: `TC-FUNC-075b` and `TC-FUNC-075c` both fail; restored, both pass.

## The six findings

| # | Finding | Move | Files |
| :- | :------ | :--- | :---- |
| 1 | `includeIgnored` has no owner | Delete `excludePatterns` | 7 |
| 2 | `list` hand-rolls its trailer | Call `pageTrailer` | 3 |
| 3 | `FilesystemServerContext` class | Class becomes interface | 1 |
| 4 | Invalid-setting warn written 3x | One `warnInvalidSetting` | 4 |
| 5 | Each tool has three names | Rename file + const to wire | 9 |
| 6 | README structure table lies | Delete two stale rows | 1 |

**1 — `includeIgnored`.** Four tools each re-derived what the flag means to a walk, and `list` derived it a third way with its own gitignore matcher. `excludePatterns` never carried a value other than `DEFAULT_EXCLUDE_PATTERNS` or `[]` at any of its five call sites, so it is deleted rather than kept, and `respectGitignore` becomes `skipIgnored` — a flag that also drops `node_modules` should not be named for gitignore alone. `searchFiles` loses a positional parameter; `GitignoreManager`, `loadRootGitignore` and `DEFAULT_EXCLUDE_PATTERNS` become internal to `glob.ts`.

**2 — the trailer.** `core/fmt.ts` states that position is owed on every page *including the last one, which has no cursor and would otherwise read as the whole answer*. `list` was the one paged tool not honoring it, so the final page of a split listing shipped a bare tree. `src/instructions.ts` had a matching false claim about where `nextCursor` appears; corrected.

**3 — the context class.** Two of its five constructor arguments fed fields that only its own `dispose` read.

**4 — the warning.** Three copies in `core/{primitives,util,observability}.ts`, three dedupe mechanisms, two output channels. Collapsed into `warnInvalidSetting` in `primitives.ts`, which its own file header already designates as the dependency-free bottom between the other two. This also removes `util.ts`'s only import of `observability.ts` — the precise edge `primitives.ts` was carved out to keep from becoming a cycle.

**5 — the names.** Five files and seven constants renamed to the wire name, so grepping `search_text` finds the file that implements it.

**6 — the README.** `scripts/` does not exist; `normalizeBatchItems` is private.

## Behavior changes

Two are deliberate and both are pinned by a new test:

- **Invalid-setting warnings are no longer level-gated.** `util.ts`'s copy went through `Logger.warn`, so an `FS_MAX_FILE_SIZE` typo was silent at `--log-level=error` while the same typo in `FS_ALLOW_SENSITIVE` printed. All three now reach stderr unconditionally. Affects `FS_MAX_FILE_SIZE`, `FS_MAX_READ_MANY_BYTES`, `FS_SEARCH_TIMEOUT_MS`, `FS_MAX_WATCHERS`, `FS_MAX_REQUEST_BYTES`, `FS_RATE_LIMIT_RPM`, `FS_KEEPALIVE_TIMEOUT_MS`.
- **`list` prunes at walk time** instead of enumerating and post-filtering, so children of an ignored directory are never visited.

One more fix rides along: `globEntries` now accepts a signal and hands it to the `.gitignore` pre-walk. That discovery pass prunes only `node_modules`/`.git`/`.hg`/`.svn` — not `dist`, `target` or `vendor` — so on a large tree it ran uncancellable and outside the calling tool's own timeout. Also pre-existing for the three search tools.

**No wire name, schema, or annotation changed.** `git diff main..HEAD -- src/tools/ | grep "name: '"` is empty.

## Tests

277 → 280, `npm run check:static` exit 0.

| Test | Pins |
| :--- | :--- |
| `TC-FUNC-019b` | warning is not level-gated, fires once |
| `TC-FUNC-075b` | pruning below the top level |
| `TC-FUNC-075c` | the file case, via `find_files` |
| `TC-FUNC-055` | the pagination text it used to walk past |
| `TC-FUNC-075` | rewritten for the new trailer format |

`TC-FUNC-075b`'s fixture is nested one level on purpose. An earlier version placed the ignored directory at depth 1 — the one depth where a function-exclude *does* drop the dirent — and passed while the leak was live.

## Process

`docs/plan/2026-09-10-arch-audit-six/` carries the plan and the adversarial review of it. The plan-hunt found one confirmed defect before execution: a step that edited a model-facing string with no gate able to see the edit. Fixed by quoting the exact replacement and extending `TC-FUNC-055` to read it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CKzu8bYgwd5mMueZgZuAU5
